### PR TITLE
Dockerfile: use one expose for both ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,8 @@ ADD config/logging.yml /crate/config/logging.yml
 
 WORKDIR /data
 
-# http
-EXPOSE 4200
-# transport
-EXPOSE 4300
+# http: 4200 tcp
+# transport: 4300 tcp
+EXPOSE 4200 4300
 
 CMD ["crate"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -21,9 +21,8 @@ ADD config/logging.yml /crate/config/logging.yml
 
 WORKDIR /data
 
-# http
-EXPOSE 4200
-# transport
-EXPOSE 4300
+# http: 4200 tcp
+# transport: 4300 tcp
+EXPOSE 4200 4300
 
 CMD ["crate"]


### PR DESCRIPTION
This change removes one layer from the images. There's no need to have two separate layers (or two operations) to expose two ports.