### PR TITLE
Switch back to Java base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,22 +4,19 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM alpine:latest
+FROM java:8-jre
 MAINTAINER Crate Technology GmbH <office@crate.io>
 
-RUN echo 'http://nl.alpinelinux.org/alpine/latest-stable/community' >> /etc/apk/repositories
-RUN apk update && \
-    apk add openjdk8-jre-base && \
-    apk add openssl && \
-    apk add python3 && \
-    rm -rf /var/cache/apk/* && \
+RUN apt-get update && \
+    apt-get install -y python3 && \
+    rm -rf /var/lib/apt && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 ENV CRATE_VERSION 0.54.6
-RUN wget -O - "https://cdn.crate.io/downloads/releases/crate-$CRATE_VERSION.tar.gz" \
-  | tar -xzC / && mv /crate-$CRATE_VERSION /crate
+RUN mkdir /crate && \
+  wget -nv -O - "https://cdn.crate.io/downloads/releases/crate-$CRATE_VERSION.tar.gz" \
+  | tar -xzC /crate --strip-components=1
 
-RUN addgroup crate && adduser -G crate -H crate -D && chown -R crate /crate
 ENV PATH /crate/bin:$PATH
 
 VOLUME ["/data"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,22 +4,19 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM alpine:latest
+FROM java:8-jre
 MAINTAINER Crate Technology GmbH <office@crate.io>
 
-RUN echo 'http://nl.alpinelinux.org/alpine/latest-stable/community' >> /etc/apk/repositories
-RUN apk update && \
-    apk add openjdk8-jre-base && \
-    apk add openssl && \
-    apk add python3 && \
-    rm -rf /var/cache/apk/* && \
+RUN apt-get update && \
+    apt-get install -y python3 && \
+    rm -rf /var/lib/apt && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 ENV CRATE_VERSION XXX
-RUN wget -O - "https://cdn.crate.io/downloads/releases/crate-$CRATE_VERSION.tar.gz" \
-  | tar -xzC / && mv /crate-$CRATE_VERSION /crate
+RUN mkdir /crate && \
+  wget -nv -O - "https://cdn.crate.io/downloads/releases/crate-$CRATE_VERSION.tar.gz" \
+  | tar -xzC /crate --strip-components=1
 
-RUN addgroup crate && adduser -G crate -H crate -D && chown -R crate /crate
 ENV PATH /crate/bin:$PATH
 
 VOLUME ["/data"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ published to the public [Docker Hub Registry][4].
 
 ## Base Docker Image
 
-- [alpine:latest][5]
+- [java:8-jre][5]
 
 ## Installation
 
@@ -137,7 +137,7 @@ we need you to agree to our [CLA][11]. For further information please refer to [
 [2]: https://registry.hub.docker.com/u/crate/crate/
 [3]: https://crate.io
 [4]: https://registry.hub.docker.com/
-[5]: https://hub.docker.com/_/alpine/
+[5]: https://registry.hub.docker.com/_/java/
 [6]: https://crate.io/docs/stable/configuration.html
 [7]: https://crate.io/docs/en/latest/best_practice/multi_node_setup.html
 [8]: https://github.com/crate/crate/blob/master/LICENSE.txt


### PR DESCRIPTION
Alpine does not contain glibc that is needed for sigar

Revert "update base image to alpine linux in README"

This reverts commit 19690cd2b281fe50421d52fa6c781856687e77c3.

Revert "changed base distro to alpine linux"

This reverts commit 578cc798f102805e25e718285943abdb2f86335a.