### PR TITLE
support arm64 architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-## -*- docker-image-name: "docker-crate" -*-
+mage-name: "docker-crate" -*-
 #
 # Crate Dockerfile
 # https://github.com/crate/docker-crate
 #
 
-FROM alpine:3.5
+FROM arm64v8/alpine:3.5
 MAINTAINER Crate.IO GmbH office@crate.io
 
 ENV GOSU_VERSION 1.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-mage-name: "docker-crate" -*-
+## -*- docker-image-name: "docker-crate" -*-
 #
 # Crate Dockerfile
 # https://github.com/crate/docker-crate


### PR DESCRIPTION
I was use FROM arm64v8/alpine:3.5 to build on arm64 architecture and worked. So I think it can be support arm64 architeture,and it can be push to the https://hub.docker.com/u/arm64v8/ . And I'm not sure whether or not to have updated generate-stackbrew-library.sh files as example to change your script