### PR TITLE
remove Sigar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN apk add --no-cache --virtual .crate-rundeps \
         openjdk8-jre-base \
         python3 \
         openssl \
-        sigar \
     && apk add --no-cache --virtual .build-deps \
         curl \
         gnupg \
@@ -47,7 +46,6 @@ RUN apk add --no-cache --virtual .crate-rundeps \
     && tar -xf crate-$CRATE_VERSION.tar.gz -C /crate --strip-components=1 \
     && rm crate-$CRATE_VERSION.tar.gz \
     && ln -s /usr/bin/python3 /usr/bin/python \
-    && rm /crate/lib/sigar/libsigar-amd64-linux.so \
     && apk del .build-deps
 
 ENV PATH /crate/bin:$PATH

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -32,7 +32,6 @@ RUN apk add --no-cache --virtual .crate-rundeps \
         openjdk8-jre-base \
         python3 \
         openssl \
-        sigar \
     && apk add --no-cache --virtual .build-deps \
         curl \
         gnupg \
@@ -47,7 +46,6 @@ RUN apk add --no-cache --virtual .crate-rundeps \
     && tar -xf crate-$CRATE_VERSION.tar.gz -C /crate --strip-components=1 \
     && rm crate-$CRATE_VERSION.tar.gz \
     && ln -s /usr/bin/python3 /usr/bin/python \
-    && rm /crate/lib/sigar/libsigar-amd64-linux.so \
     && apk del .build-deps
 
 ENV PATH /crate/bin:$PATH

--- a/tests/itests.py
+++ b/tests/itests.py
@@ -175,7 +175,7 @@ class EnvironmentVariablesTest(DockerBaseTestCase):
         self.assertEqual('256m', res[0][len('-Xms'):])
 
 
-class SigarStatsTest(DockerBaseTestCase):
+class OsStatsTest(DockerBaseTestCase):
     """
     docker run crate
     """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -12,7 +12,7 @@ import unittest
 from requests.exceptions import ConnectionError
 
 from itests import SimpleRunTest, JavaPropertiesTest, \
-    EnvironmentVariablesTest, SigarStatsTest, TarballRemovedTest
+    EnvironmentVariablesTest, OsStatsTest, TarballRemovedTest
 
 DIR = os.path.dirname(__file__)
 
@@ -56,7 +56,7 @@ def test_suite():
     suite.addTest(SimpleRunTest(docker_layer))
     suite.addTest(JavaPropertiesTest(docker_layer))
     suite.addTest(EnvironmentVariablesTest(docker_layer))
-    suite.addTest(SigarStatsTest(docker_layer))
+    suite.addTest(OsStatsTest(docker_layer))
     suite.addTest(TarballRemovedTest(docker_layer))
     suite.layer = docker_layer
     return suite


### PR DESCRIPTION
Sigar won't be part of future CrateDB releases with versions >=2.3

**WARNING**: WAIT FOR MERGE UNTIL CRATE VERSION 2.3