### PR TITLE
update alpine base image to v3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM alpine:3.5
+FROM alpine:3.7
 MAINTAINER Crate.IO GmbH office@crate.io
 
 ENV GOSU_VERSION 1.9

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,7 +4,7 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM alpine:3.5
+FROM alpine:3.7
 MAINTAINER Crate.IO GmbH office@crate.io
 
 ENV GOSU_VERSION 1.9


### PR DESCRIPTION
The update fixes a java 8 vulnerability on version 121 which is the
latest version on alpine v3.5.
Alpine v3.7 contains Java 8 version 151 in its package repo.