### PR TITLE
added new Dockerfile template for CrateDB 2.3

### DIFF
--- a/Dockerfile_2.3.template
+++ b/Dockerfile_2.3.template
@@ -1,0 +1,69 @@
+## -*- docker-image-name: "docker-crate" -*-
+#
+# Crate Dockerfile
+# https://github.com/crate/docker-crate
+#
+
+FROM alpine:3.7
+MAINTAINER Crate.IO GmbH office@crate.io
+
+ENV GOSU_VERSION 1.9
+RUN set -x \
+    && apk add --no-cache --virtual .gosu-deps \
+        dpkg \
+        gnupg \
+        curl \
+    && export ARCH=$(echo $(dpkg --print-architecture) | cut -d"-" -f3) \
+    && curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$ARCH" \
+    && curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$ARCH.asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu nobody true \
+    && apk del .gosu-deps
+
+RUN addgroup crate && adduser -G crate -H crate -D
+
+# install crate
+ENV CRATE_VERSION XXX
+RUN apk add --no-cache --virtual .crate-rundeps \
+        openjdk8-jre-base \
+        python3 \
+        openssl \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+        gnupg \
+        tar \
+    && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-$CRATE_VERSION.tar.gz \
+    && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-$CRATE_VERSION.tar.gz.asc \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
+    && gpg --batch --verify crate-$CRATE_VERSION.tar.gz.asc crate-$CRATE_VERSION.tar.gz \
+    && rm -r "$GNUPGHOME" crate-$CRATE_VERSION.tar.gz.asc \
+    && mkdir /crate \
+    && tar -xf crate-$CRATE_VERSION.tar.gz -C /crate --strip-components=1 \
+    && rm crate-$CRATE_VERSION.tar.gz \
+    && ln -s /usr/bin/python3 /usr/bin/python \
+    && apk del .build-deps
+
+ENV PATH /crate/bin:$PATH
+# Default heap size for Docker, can be overwritten by args
+ENV CRATE_HEAP_SIZE 512M
+
+VOLUME ["/data"]
+
+ADD config/crate.yml /crate/config/crate.yml
+ADD config/log4j2.properties /crate/config/log4j2.properties
+COPY docker-entrypoint.sh /
+
+WORKDIR /data
+
+# http: 4200 tcp
+# transport: 4300 tcp
+# postgres protocol ports: 5432 tcp
+EXPOSE 4200 4300 5432
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["crate"]

--- a/update.sh
+++ b/update.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -x
 
-if [[ -z "$1" ]]; then
+if [[ -z "$1" || -z "$2" ]]; then
     echo "update.sh <version> <template>"
     exit 1
 else
-    TAG=$1
-    TEMPLATE=${2:-"Dockerfile"}
+    TAG="$1"
+    TEMPLATE="$2.template"
     VERSION=`echo $TAG | cut -d '-' -f 1`
 fi
 
@@ -23,9 +23,10 @@ if [ "$TAG" == "$TAG_EXISTS" ]; then
     exit 1
 fi
 
-if [[ ! -f "$TEMPLATE.template" ]]; then
-    echo "Template $TEMPLATE.template does not exist"
+if [[ ! -f "$TEMPLATE" ]]; then
+    echo "Template $TEMPLATE does not exist"
     exit 1
 fi
 
-sed "s/XXX/$VERSION/g" "$TEMPLATE.template" > Dockerfile
+exit 0
+sed "s/XXX/$VERSION/g" "$TEMPLATE" > Dockerfile


### PR DESCRIPTION
that removes the Sigar library dependency

**When bumping a version of CrateDB 2.3.x or greater then this template needs to be used.**