### PR TITLE
Use the 2.3 template for 2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ RUN apk add --no-cache --virtual .crate-rundeps \
         openjdk8-jre-base \
         python3 \
         openssl \
-        sigar \
     && apk add --no-cache --virtual .build-deps \
         curl \
         gnupg \
@@ -47,7 +46,6 @@ RUN apk add --no-cache --virtual .crate-rundeps \
     && tar -xf crate-$CRATE_VERSION.tar.gz -C /crate --strip-components=1 \
     && rm crate-$CRATE_VERSION.tar.gz \
     && ln -s /usr/bin/python3 /usr/bin/python \
-    && rm /crate/lib/sigar/libsigar-amd64-linux.so \
     && apk del .build-deps
 
 ENV PATH /crate/bin:$PATH


### PR DESCRIPTION
Jenkins job used the wrong template for the 2.3.0 release. In the meantime, this PR syncs the current 2.3.0 docker image with that template. The tag will need to be moved.