### PR TITLE
Update to support ARM64v8 architecture

### DIFF
--- a/entrypoint_3.0.sh
+++ b/entrypoint_3.0.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ae
 


### PR DESCRIPTION
 - Use Ubuntu:16.04 as JVM is crashing on Alpine-ARM64v8.
 - Update GOSU to use architecture specific version.
 - Modify entrypoint to use bash instead of sh.

This has been tested and verifed with both ```amd64 & arm64v8``` architectures

```By using the changes, Crate is working very well on AMD64 & ARM64v8 architecures```

Signed-off-by: odidev <odidev@puresoftware.com>