### PR TITLE
Add crash standalone version check and GPG signature verification

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -50,7 +50,13 @@ RUN apk add --no-cache --virtual .crate-rundeps \
 
 # install crash
 ENV CRASH_VERSION YYY
-RUN curl -o /usr/local/bin/crash https://cdn.crate.io/downloads/releases/crash_standalone_$CRASH_VERSION \
+RUN curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_$CRASH_VERSION \
+    && curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_$CRASH_VERSION.asc \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
+    && gpg --batch --verify crash_standalone_$CRASH_VERSION.asc crash_standalone_$CRASH_VERSION \
+    && rm -rf "$GNUPGHOME" crash_standalone_$CRASH_VERSION.asc \
+    && mv crash_standalone_$CRASH_VERSION /usr/local/bin/crash
     && chmod +x /usr/local/bin/crash
 
 ENV PATH /crate/bin:$PATH

--- a/update.sh
+++ b/update.sh
@@ -49,6 +49,13 @@ if [ "$?" != "0" ]; then
     exit 1
 fi
 
+CRASH_VERSION_EXISTS=$(curl -fsSI https://cdn.crate.io/downloads/releases/crash_standalone_$CRASH_VERSION)
+
+if [ "$?" != "0" ]; then
+    echo "crash version $CRASH_VERSION doesn't exist!"
+    exit 1
+fi
+
 TAG_EXISTS=$(git tag | grep $TAG)
 
 if [ "$TAG" == "$TAG_EXISTS" ]; then


### PR DESCRIPTION
We currently don't verify that the standalone Crash that is downloaded in the Docker build phase has been downloaded correctly (either incompletely or has been modified in transit). This commit lets us embed the checksum for the standalone Crash into the dockerfile, which is them verified using `sha256sum`.

If the checksum is incorrect, the docker build will fail.