### PR TITLE
Base Crate Docker image from CentOS 7, not Alpine

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,16 +4,13 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM alpine:3.7
+FROM centos:7
 MAINTAINER Crate.IO GmbH office@crate.io
 
 ENV GOSU_VERSION 1.9
 RUN set -x \
-    && apk add --no-cache --virtual .gosu-deps \
-        dpkg \
-        gnupg \
-        curl \
-    && export ARCH=$(echo $(dpkg --print-architecture) | cut -d"-" -f3) \
+    && yum update -y \
+    && export ARCH=amd64 \
     && curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$ARCH" \
     && curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$ARCH.asc" \
     && export GNUPGHOME="$(mktemp -d)" \
@@ -21,21 +18,14 @@ RUN set -x \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
-    && gosu nobody true \
-    && apk del .gosu-deps
+    && gosu nobody true
 
-RUN addgroup crate && adduser -G crate -H crate -D
+RUN groupadd crate && adduser -g crate -M crate
 
 # install crate
 ENV CRATE_VERSION XXX
-RUN apk add --no-cache --virtual .crate-rundeps \
-        openjdk8-jre-base \
-        python3 \
-        openssl \
-        curl \
-    && apk add --no-cache --virtual .build-deps \
-        gnupg \
-        tar \
+RUN yum install -y centos-release-scl \
+    && yum install -y rh-python36 openssl java-1.8.0-openjdk \
     && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-$CRATE_VERSION.tar.gz \
     && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-$CRATE_VERSION.tar.gz.asc \
     && export GNUPGHOME="$(mktemp -d)" \
@@ -45,28 +35,19 @@ RUN apk add --no-cache --virtual .crate-rundeps \
     && mkdir /crate \
     && tar -xf crate-$CRATE_VERSION.tar.gz -C /crate --strip-components=1 \
     && rm crate-$CRATE_VERSION.tar.gz \
-    && ln -s /usr/bin/python3 /usr/bin/python \
-    && apk del .build-deps
+    && ln -sf /usr/bin/python3 /usr/bin/python
 
 # install crash
 ENV CRASH_VERSION YYY
-RUN apk add --no-cache --virtual .build-deps \
-        gnupg \
-    && curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_$CRASH_VERSION \
+RUN curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_$CRASH_VERSION \
     && curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_$CRASH_VERSION.asc \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
     && gpg --batch --verify crash_standalone_$CRASH_VERSION.asc crash_standalone_$CRASH_VERSION \
     && rm -rf "$GNUPGHOME" crash_standalone_$CRASH_VERSION.asc \
     && mv crash_standalone_$CRASH_VERSION /usr/local/bin/crash \
-    && chmod +x /usr/local/bin/crash \
-    && apk del .build-deps
+    && chmod +x /usr/local/bin/crash
 
-# by default java caches DNS lookups forever, which we don't want in a dynamic
-# environment. Negative DNS lookups are cached for 10s, which can lead to race
-# conditions when e.g. a docker stack services is being started
-RUN echo "networkaddress.cache.ttl=10" >> /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/policy/java.security
-RUN echo "networkaddress.cache.negative.ttl=5" >> /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/policy/java.security
 
 ENV PATH /crate/bin:$PATH
 # Default heap size for Docker, can be overwritten by args


### PR DESCRIPTION
This builds and runs. After this, I'd like to do a couple of cleanup tasks:

1. See whether or not its nicer to install from the yum repo for crate, rather than as a tarball.
2. Use multistage builds to make the whole process a little nicer/logically seperated.
3. A bit more dockerfile cleanup, maybe see if I can optimize the image.