### PR TITLE
Base Crate Docker image from Ubuntu 16.04, not Alpine

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -4,38 +4,32 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM alpine:3.7
+FROM ubuntu:16.04
 MAINTAINER Crate.IO GmbH office@crate.io
 
 ENV GOSU_VERSION 1.9
 RUN set -x \
-    && apk add --no-cache --virtual .gosu-deps \
-        dpkg \
-        gnupg \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
         curl \
-    && export ARCH=$(echo $(dpkg --print-architecture) | cut -d"-" -f3) \
-    && curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$ARCH" \
-    && curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$ARCH.asc" \
+    && curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+    && curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
-    && gosu nobody true \
-    && apk del .gosu-deps
+    && gosu nobody true
 
-RUN addgroup crate && adduser -G crate -H crate -D
+RUN groupadd -r crate && useradd -r -g crate crate
+
 
 # install crate
 ENV CRATE_VERSION XXX
-RUN apk add --no-cache --virtual .crate-rundeps \
-        openjdk8-jre-base \
+RUN apt-get install -y --no-install-recommends \
+        openjdk-8-jre \
         python3 \
-        openssl \
-        curl \
-    && apk add --no-cache --virtual .build-deps \
-        gnupg \
-        tar \
     && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-$CRATE_VERSION.tar.gz \
     && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-$CRATE_VERSION.tar.gz.asc \
     && export GNUPGHOME="$(mktemp -d)" \
@@ -45,28 +39,18 @@ RUN apk add --no-cache --virtual .crate-rundeps \
     && mkdir /crate \
     && tar -xf crate-$CRATE_VERSION.tar.gz -C /crate --strip-components=1 \
     && rm crate-$CRATE_VERSION.tar.gz \
-    && ln -s /usr/bin/python3 /usr/bin/python \
-    && apk del .build-deps
+    && ln -s /usr/bin/python3 /usr/bin/python
 
 # install crash
 ENV CRASH_VERSION YYY
-RUN apk add --no-cache --virtual .build-deps \
-        gnupg \
-    && curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_$CRASH_VERSION \
+RUN curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_$CRASH_VERSION \
     && curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_$CRASH_VERSION.asc \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
     && gpg --batch --verify crash_standalone_$CRASH_VERSION.asc crash_standalone_$CRASH_VERSION \
     && rm -rf "$GNUPGHOME" crash_standalone_$CRASH_VERSION.asc \
     && mv crash_standalone_$CRASH_VERSION /usr/local/bin/crash \
-    && chmod +x /usr/local/bin/crash \
-    && apk del .build-deps
-
-# by default java caches DNS lookups forever, which we don't want in a dynamic
-# environment. Negative DNS lookups are cached for 10s, which can lead to race
-# conditions when e.g. a docker stack services is being started
-RUN echo "networkaddress.cache.ttl=10" >> /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/policy/java.security
-RUN echo "networkaddress.cache.negative.ttl=5" >> /usr/lib/jvm/java-1.8-openjdk/jre/lib/security/policy/java.security
+    && chmod +x /usr/local/bin/crash
 
 ENV PATH /crate/bin:$PATH
 # Default heap size for Docker, can be overwritten by args

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -7,29 +7,15 @@
 FROM ubuntu:16.04
 MAINTAINER Crate.IO GmbH office@crate.io
 
-ENV GOSU_VERSION 1.9
-RUN set -x \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-        ca-certificates \
-        curl \
-    && curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-    && curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    && gosu nobody true
-
-RUN groupadd -r crate && useradd -r -g crate crate
-
+RUN groupadd -g 1000 crate && useradd -u 1000 -g 1000 -d /crate crate
 
 # install crate
 ENV CRATE_VERSION XXX
-RUN apt-get install -y --no-install-recommends \
-        openjdk-8-jre \
-        python3 \
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+       openjdk-8-jre \
+       python3 \
+       curl \
     && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-$CRATE_VERSION.tar.gz \
     && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-$CRATE_VERSION.tar.gz.asc \
     && export GNUPGHOME="$(mktemp -d)" \
@@ -66,8 +52,11 @@ RUN mkdir -p /data/data /data/log
 
 VOLUME /data
 
-ADD config/crate.yml /crate/config/crate.yml
-ADD config/log4j2.properties /crate/config/log4j2.properties
+COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
+COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
+
+RUN chown -R crate:0 /crate && chmod -R g=u /crate
+
 COPY docker-entrypoint.sh /
 
 WORKDIR /data

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ae
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,7 +18,7 @@ fi
 
 if [ "$1" = 'crate' -a "$(id -u)" = '0' ]; then
     chown -R crate:crate /data
-    set -- gosu crate "$@"
+    exec chroot --userspec=1000 / "$@"
 fi
 
 exec "$@"


### PR DESCRIPTION
See the comments here https://github.com/crate/docker-crate/pull/128#issuecomment-439035827 and https://github.com/crate/docker-crate/issues/116#issuecomment-439020050

This PR replaces Alpine with Ubuntu, gosu uses the correct architecture specific version, and makes the entrypoint use bash instead of sh.

This is contrast with our original plan to use CentOS. I'll run it by everyone and verify that it works for the use cases we're making this change for.