### PR TITLE
Revert to Alpine, Refactor HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV CRATE_HEAP_SIZE 512M
 # if we cannot get any response from the CrateDB (connection refused, timeout
 # etc). If any response is received (regardless of http status code) we
 # consider the node as running.
-HEALTHCHECK --timeout=30s --interval=30s CMD curl --fail --max-time 25 $(hostname):4200
+HEALTHCHECK --timeout=30s --interval=30s CMD curl --max-time 25 $(hostname):4200 || exit 1
 
 RUN mkdir -p /data/data /data/log
 

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -4,18 +4,23 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM centos:7.5.1804
+FROM alpine:3.8
 
-RUN groupadd crate && useradd -u 1000 -g crate -d /crate crate
+RUN addgroup -g 1000 -S crate \
+    && adduser -u 1000 -G crate -h /crate -S crate
 
 COPY docker-entrypoint.sh /
 
 # install crate
-RUN yum install -y yum-utils https://centos7.iuscommunity.org/ius-release.rpm \
-    && yum makecache \
-    && yum install -y python36u openssl java-1.8.0-openjdk \
-    && yum clean all \
-    && rm -rf /var/cache/yum \
+RUN apk add --no-cache --virtual .crate-rundeps \
+        openjdk8-jre-base \
+        python3 \
+        openssl \
+        curl \
+        coreutils \
+    && apk add --no-cache --virtual .build-deps \
+        gnupg \
+        tar \
     && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-{{ CRATE_VERSION }}.tar.gz \
     && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-{{ CRATE_VERSION }}.tar.gz.asc \
     && export GNUPGHOME="$(mktemp -d)" \
@@ -24,20 +29,24 @@ RUN yum install -y yum-utils https://centos7.iuscommunity.org/ius-release.rpm \
     && rm -rf "$GNUPGHOME" crate-{{ CRATE_VERSION }}.tar.gz.asc \
     && tar -xf crate-{{ CRATE_VERSION }}.tar.gz -C /crate --strip-components=1 \
     && rm crate-{{ CRATE_VERSION }}.tar.gz \
-    && ln -sf /usr/bin/python3.6 /usr/bin/python3
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && apk del .build-deps
 
 COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
 COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
 
 # install crash
-RUN curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_{{ CRASH_VERSION }}\
+RUN apk add --no-cache --virtual .build-deps \
+        gnupg \
+    && curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_{{ CRASH_VERSION }}\
     && curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_{{ CRASH_VERSION }}.asc \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
     && gpg --batch --verify crash_standalone_{{ CRASH_VERSION }}.asc crash_standalone_{{ CRASH_VERSION }} \
     && rm -rf "$GNUPGHOME" crash_standalone_{{ CRASH_VERSION }}.asc \
     && mv crash_standalone_{{ CRASH_VERSION }} /usr/local/bin/crash \
-    && chmod +x /usr/local/bin/crash
+    && chmod +x /usr/local/bin/crash \
+    && apk del .build-deps
 
 ENV PATH /crate/bin:$PATH
 # Default heap size for Docker, can be overwritten by args

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -56,7 +56,7 @@ ENV CRATE_HEAP_SIZE 512M
 # if we cannot get any response from the CrateDB (connection refused, timeout
 # etc). If any response is received (regardless of http status code) we
 # consider the node as running.
-HEALTHCHECK --timeout=30s --interval=30s CMD curl --fail --max-time 25 $(hostname):4200
+HEALTHCHECK --timeout=30s --interval=30s CMD curl --max-time 25 $(hostname):4200 || exit 1
 
 RUN mkdir -p /data/data /data/log
 

--- a/tests/itests.py
+++ b/tests/itests.py
@@ -101,13 +101,15 @@ class DockerBaseTestCase(TestCase):
         return key and top.get(key) or top
 
     def crate_process(self):
-        proc = self.info(u'Processes')
-        if not proc:
+        procs = self.info(u'Processes')
+        if not procs:
             return ''
-        for p in proc[0]:
-            if p.startswith('/bin/java'):
-                print_debug('>>>', p)
-                return p
+
+        for proc in procs:
+            for p in proc:
+                if p.startswith('java'):
+                    print_debug('>>>', p)
+                    return p
         return ''
 
     def logs(self):
@@ -272,7 +274,7 @@ class TarballRemovedTest(DockerBaseTestCase):
         self.wait_for_cluster()
         id = self.cli.exec_create('crate', 'ls -la /crate-*')
         res = self.cli.exec_start(id['Id'])
-        self.assertEqual(b'ls: cannot access /crate-*: No such file or directory\n', res)
+        self.assertEqual(b"ls: cannot access '/crate-*': No such file or directory\n", res)
 
 
 class HealthcheckTest(DockerBaseTestCase):
@@ -291,7 +293,7 @@ class HealthcheckTest(DockerBaseTestCase):
             'crate', '/bin/sh -c "echo > /etc/resolv.conf"')
         self.cli.exec_start(id['Id'])
 
-        id = self.cli.exec_create('crate', '/bin/sh -c "echo 127.0.0.2  $(hostname) > /etc/hosts"')
+        id = self.cli.exec_create('crate', '/bin/sh -c "echo > /etc/hosts"')
         self.cli.exec_start(id['Id'])
 
         container_config = self.cli.inspect_container(self.container)['Config']


### PR DESCRIPTION
# Commit 1 // CentOS7 -> Alpine3.8
This partially reverts the change from b1289dd.
The Official Images maintainers raised concerns about us making such a
drastic change between minor versions, which we agreed with.

Additionally, the reasons for moving to CentOS in the first place were
erroneous. Given the increased image size and no real benefit given to
us to use CentOS, we have thus decided to revert to Alpine.

# Commit 2 // Removing `--fail` from HEALTCHECK
As stated in the HEALTHCHECK's documentation, the check is supposed to
indicate whether the CrateDB node is running and that if a response is
recieved, regardless of status code, consider it running.

With --fail given as an option to curl, it *does* take into account the
status code. This behaviour has caused problems in Swarm environments,
and generally does not agree with the documented intention of the check.

@chaudum @seut Would it be easier for us to discuss the HEALTHCHECK issue in this PR? That way, it's a little more async and transparent.

@lag-linaro Is `alpine:3.8` suitable for your `arm64v8` needs? The image says it supports it, but I'd just like to verify. :slightly_smiling_face: 
