### PR TITLE
Use the $TEMPLATE environment variable for the jinja template, not a hard coded one

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -74,4 +74,4 @@ jinja2 \
     -D CRATE_VERSION=$CRATE_VERSION \
     -D CRASH_VERSION=$CRASH_VERSION \
     -D BUILD_TIMESTAMP=$BUILD_TIMESTAMP \
-    Dockerfile.j2 > Dockerfile
+    $TEMPLATE > Dockerfile


### PR DESCRIPTION
My bad, this functionality was removed when I ported over to jinja. This will let us use version specific jinja templates again.