### PR TITLE
Fix python symlink, centos package doesn't link python3.6 to python3

### DIFF
--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -32,7 +32,8 @@ RUN yum install -y yum-utils https://centos7.iuscommunity.org/ius-release.rpm \
     && rm -rf "$GNUPGHOME" crate-{{ CRATE_VERSION }}.tar.gz.asc \
     && tar -xf crate-{{ CRATE_VERSION }}.tar.gz -C /crate --strip-components=1 \
     && rm crate-{{ CRATE_VERSION }}.tar.gz \
-    && ln -sf /usr/bin/python3 /usr/bin/python
+    && ln -sf /usr/bin/python3.6 /usr/bin/python3
+    && ln -sf /usr/bin/python3.6 /usr/bin/python
 
 COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
 COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties


### PR DESCRIPTION
Relates https://github.com/crate/docker-crate/issues/148.