### PR TITLE
Move consecutive COPY commands to avoid Docker bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,12 @@ WORKDIR /data
 # postgres protocol ports: 5432 tcp
 EXPOSE 4200 4300 5432
 
+# These COPY commands have been moved before the last one due to the following issues:
+# https://github.com/moby/moby/issues/37965#issuecomment-448926448
+# https://github.com/moby/moby/issues/38866
+COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
+COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
+
 LABEL maintainer="Crate.io <office@crate.io>" \
     org.label-schema.schema-version="1.0" \
     org.label-schema.build-date="2019-03-11T17:11:13.010861050+00:00" \
@@ -73,8 +79,6 @@ LABEL maintainer="Crate.io <office@crate.io>" \
     org.label-schema.vendor="Crate.io" \
     org.label-schema.version="3.2.5"
 
-COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
-COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -63,6 +63,12 @@ WORKDIR /data
 # postgres protocol ports: 5432 tcp
 EXPOSE 4200 4300 5432
 
+# These COPY commands have been moved before the last one due to the following issues:
+# https://github.com/moby/moby/issues/37965#issuecomment-448926448
+# https://github.com/moby/moby/issues/38866
+COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
+COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
+
 LABEL maintainer="Crate.io <office@crate.io>" \
     org.label-schema.schema-version="1.0" \
     org.label-schema.build-date="{{ BUILD_TIMESTAMP }}" \
@@ -73,8 +79,6 @@ LABEL maintainer="Crate.io <office@crate.io>" \
     org.label-schema.vendor="Crate.io" \
     org.label-schema.version="{{ CRATE_VERSION }}"
 
-COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
-COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile_3.1.j2
+++ b/Dockerfile_3.1.j2
@@ -58,6 +58,12 @@ WORKDIR /data
 # postgres protocol ports: 5432 tcp
 EXPOSE 4200 4300 5432
 
+# These COPY commands have been moved before the last one due to the following issues:
+# https://github.com/moby/moby/issues/37965#issuecomment-448926448
+# https://github.com/moby/moby/issues/38866
+COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
+COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
+
 LABEL maintainer="Crate.io <office@crate.io>" \
     org.label-schema.schema-version="1.0" \
     org.label-schema.build-date="{{ BUILD_TIMESTAMP }}" \
@@ -68,8 +74,6 @@ LABEL maintainer="Crate.io <office@crate.io>" \
     org.label-schema.vendor="Crate.io" \
     org.label-schema.version="{{ CRATE_VERSION }}"
 
-COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
-COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
 COPY docker-entrypoint_3.1.sh /docker-entrypoint.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

There seems to be a bug in docker affecting Jenkins' ability (as well as
my own, locally) to build docker images with 3 consecutive COPY/ADD
commands. Previously, this would result in:

```
 ---> d21806a43c11
Step 17/21 : COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
 ---> d3ce15d62c5f
Step 18/21 : COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
 ---> 3e09f7cc5247
Step 19/21 : COPY docker-entrypoint.sh /
failed to export image: failed to create image: failed to get layer sha256:da5198c8160f19dfcd3a574a0ca58243c26e40f9eeacba76a5f5428a41cd7616: layer does not exist
```

Running the docker build a second time would pass successfuly. This has
been reported in multiple places:

https://github.com/moby/moby/issues/37965#issuecomment-448926448
https://github.com/moby/moby/issues/38866

Moving 2 copy commands before the label and keeping the docker
entrypoint addition afterwards circumvents this issue.

A little ugly, but until it is fixed in Docker, we can't build/deploy
our CrateDB images on Jenkins.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed