### PR TITLE
Accept tarball URL as input for update.py script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 parts/
 .installed.cfg
 
+.mypy_cache/

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -1,3 +1,5 @@
+{%- set CRATE_TAR_GZ   = CRATE_URL.split("/")[-1] -%}
+{%- set CRATE_FILENAME = CRATE_TAR_GZ.replace(".tar.gz", "") -%}
 ## -*- docker-image-name: "docker-crate" -*-
 #
 # Crate Dockerfile
@@ -24,14 +26,14 @@ RUN yum install -y yum-utils https://centos7.iuscommunity.org/ius-release.rpm \
     && yum install -y python36u openssl \
     && yum clean all \
     && rm -rf /var/cache/yum \
-    && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-{{ CRATE_VERSION }}.tar.gz \
-    && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-{{ CRATE_VERSION }}.tar.gz.asc \
+    && curl -fSL -O {{ CRATE_URL }} \
+    && curl -fSL -O {{ CRATE_URL }}.asc \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
-    && gpg --batch --verify crate-{{ CRATE_VERSION }}.tar.gz.asc crate-{{ CRATE_VERSION }}.tar.gz \
-    && rm -rf "$GNUPGHOME" crate-{{ CRATE_VERSION }}.tar.gz.asc \
-    && tar -xf crate-{{ CRATE_VERSION }}.tar.gz -C /crate --strip-components=1 \
-    && rm crate-{{ CRATE_VERSION }}.tar.gz \
+    && gpg --batch --verify {{ CRATE_TAR_GZ }}.asc {{ CRATE_TAR_GZ }} \
+    && rm -rf "$GNUPGHOME" {{ CRATE_TAR_GZ }}.asc \
+    && tar -xf {{ CRATE_TAR_GZ }} -C /crate --strip-components=1 \
+    && rm {{ CRATE_TAR_GZ }} \
     && ln -sf /usr/bin/python3.6 /usr/bin/python3 \
     && ln -sf /usr/bin/python3.6 /usr/bin/python
 
@@ -39,8 +41,8 @@ COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
 COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
 
 # install crash
-RUN curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_{{ CRASH_VERSION }}\
-    && curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_{{ CRASH_VERSION }}.asc \
+RUN curl -fSL -O {{ CRASH_URL }} \
+    && curl -fSL -O {{ CRASH_URL }}.asc \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
     && gpg --batch --verify crash_standalone_{{ CRASH_VERSION }}.asc crash_standalone_{{ CRASH_VERSION }} \

--- a/Dockerfile_3.1.j2
+++ b/Dockerfile_3.1.j2
@@ -1,3 +1,5 @@
+{%- set CRATE_TAR_GZ   = CRATE_URL.split("/")[-1] -%}
+{%- set CRATE_FILENAME = CRATE_TAR_GZ.replace(".tar.gz", "") -%}
 ## -*- docker-image-name: "docker-crate" -*-
 #
 # Crate Dockerfile
@@ -19,22 +21,22 @@ RUN apk add --no-cache --virtual .crate-rundeps \
     && apk add --no-cache --virtual .build-deps \
         gnupg \
         tar \
-    && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-{{ CRATE_VERSION }}.tar.gz \
-    && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-{{ CRATE_VERSION }}.tar.gz.asc \
+    && curl -fSL -O {{ CRATE_URL }} \
+    && curl -fSL -O {{ CRATE_URL }}.asc \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
-    && gpg --batch --verify crate-{{ CRATE_VERSION }}.tar.gz.asc crate-{{ CRATE_VERSION }}.tar.gz \
-    && rm -rf "$GNUPGHOME" crate-{{ CRATE_VERSION }}.tar.gz.asc \
-    && tar -xf crate-{{ CRATE_VERSION }}.tar.gz -C /crate --strip-components=1 \
-    && rm crate-{{ CRATE_VERSION }}.tar.gz \
+    && gpg --batch --verify {{ CRATE_TAR_GZ }}.asc {{ CRATE_TAR_GZ }} \
+    && rm -rf "$GNUPGHOME" {{ CRATE_TAR_GZ }}.asc \
+    && tar -xf {{ CRATE_TAR_GZ }} -C /crate --strip-components=1 \
+    && rm {{ CRATE_TAR_GZ }} \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && apk del .build-deps
 
 # install crash
 RUN apk add --no-cache --virtual .build-deps \
         gnupg \
-    && curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_{{ CRASH_VERSION }}\
-    && curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_{{ CRASH_VERSION }}.asc \
+    && curl -fSL -O {{ CRASH_URL }} \
+    && curl -fSL -O {{ CRASH_URL }}.asc \
     && export GNUPGHOME="$(mktemp -d)" \
     && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
     && gpg --batch --verify crash_standalone_{{ CRASH_VERSION }}.asc crash_standalone_{{ CRASH_VERSION }} \

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -51,4 +51,3 @@ zope.interface = 4.1.2
 # Required by:
 # zc.recipe.testrunner==2.0.0
 zope.testrunner = 4.4.6
-

--- a/tests/itests.py
+++ b/tests/itests.py
@@ -144,7 +144,7 @@ class SimpleRunTest(DockerBaseTestCase):
     def testRun(self):
         self.wait_for_cluster()
         lg = self.logs().decode("utf-8").split('\n')
-        self.assertTrue('new_master' in lg[-3:][0])
+        self.assertTrue('elected-as-master' in lg[-4:][0])
         self.assertTrue(lg[-2:][0].endswith('started'))
 
 

--- a/update.py
+++ b/update.py
@@ -84,6 +84,7 @@ def main():
     args = parser.parse_args()
 
     cratedb_version = ensure_existing_cratedb(args.cratedb_version)
+    crash_version = ensure_existing_crash(args.crash_version)
     jdk_version_default = Version(12, 0, 1) if cratedb_version.major >= 4 else Version(11, 0, 1)
     jdk_version = args.jdk_version or jdk_version_default
     jdk_url, jdk_sha256 = jdk_url_and_sha(jdk_version)
@@ -92,8 +93,8 @@ def main():
     env = Environment(loader=FileSystemLoader(os.path.dirname(__file__)))
     template = env.get_template(template)
     print(template.render(
-        CRATE_VERSION=ensure_existing_cratedb(args.cratedb_version),
-        CRASH_VERSION=ensure_existing_crash(args.crash_version),
+        CRATE_VERSION=cratedb_version,
+        CRASH_VERSION=crash_version,
         JDK_VERSION=str(jdk_version),
         JDK_URL=jdk_url,
         JDK_SHA256=jdk_sha256,


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

See individual commit messages:

* Commit: 8c99788
  Fix tests for CrateDB >= 4.0

* Commit: 127bc3e
  Add mypy cache directory to .gitignore file

* Commit: 37023a7
  Remove duplicate request to check if CrateDB version exists

  `ensure_existing_cratedb()` performs an HTTP request and is called
  twice after another. Storing the result of the first method call can
  reduce the amount of requests.

* Commit: 550e37e
  Add `--cratedb-tarball` argument to `update.py` script

  The new argument lets you specify a tarball location relative to the
  release URL (https://cdn.crate.io/downloads/releases/`, which is
  mutually exclusive to the `--cratedb-version` argument.

  The argument can be used to print the Dockerfile for CrateDB nightly
  builds, e.g:

  $ python3 update.py --cratedb-tarball nightly/crate-4.0.1-201907010200-7fc712f.tar.gz

* Commit: 1e500e0
  Use CRASH_URL in Dockerfile template