### PR TITLE
Update Jinja2 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-Jinja2==2.10
-jinja2-cli==0.6.0
+Jinja2==2.10.1


### PR DESCRIPTION
This commit updates Jinja2 to the latest hotfix release and removes the
unused jinja2-cli dependency.

See also https://github.com/crate/docker-crate/network/alerts