### PR TITLE
Bump openjdk to version 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,15 @@ FROM centos:7
 
 RUN groupadd crate && useradd -u 1000 -g crate -d /crate crate
 
-RUN curl --retry 8 -o /openjdk.tar.gz https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz \
-    && echo "151eb4ec00f82e5e951126f572dc9116104c884d97f91be14ec11e85fc2dd626 */openjdk.tar.gz" | sha256sum -c - \
+RUN curl --retry 8 -o /openjdk.tar.gz https://download.java.net/java/GA/jdk13/5b8a42f3905b406298b72d750b6919f6/33/GPL/openjdk-13_linux-x64_bin.tar.gz \
+    && echo "5f547b8f0ffa7da517223f6f929a5055d749776b1878ccedbd6cc1334f4d6f4d */openjdk.tar.gz" | sha256sum -c - \
     && tar -C /opt -zxf /openjdk.tar.gz \
     && rm /openjdk.tar.gz
 
-ENV JAVA_HOME /opt/jdk-12.0.1
+ENV JAVA_HOME /opt/jdk-13
 
 # REF: https://github.com/elastic/elasticsearch-docker/issues/171
-RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /opt/jdk-12.0.1/lib/security/cacerts
+RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /opt/jdk-13/lib/security/cacerts
 
 # install crate
 RUN yum install -y yum-utils https://centos7.iuscommunity.org/ius-release.rpm \

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -129,6 +129,7 @@ if version is None and not options.accept_buildout_test_releases:
 
     def _final_version(parsed_version):
         for part in parsed_version:
+            part = "{}".format(part)
             if (part[:1] == '*') and (part not in _final_parts):
                 return False
         return True
@@ -142,7 +143,7 @@ if version is None and not options.accept_buildout_test_releases:
         bestv = None
         for dist in index[req.project_name]:
             distv = dist.parsed_version
-            if _final_version(distv):
+            if _final_version((distv,)):
                 if bestv is None or distv > bestv:
                     best = [dist]
                     bestv = distv

--- a/update.py
+++ b/update.py
@@ -12,6 +12,7 @@ from urllib.request import urlopen, Request
 
 RELEASE_URL = 'https://cdn.crate.io/downloads/releases/'
 JDK_URLS = {
+    (13, 0, 0): 'https://download.java.net/java/GA/jdk13/5b8a42f3905b406298b72d750b6919f6/33/GPL/openjdk-13_linux-x64_bin.tar.gz',
     (12, 0, 1): 'https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz',
     (11, 0, 1): 'https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz'
 }
@@ -110,7 +111,7 @@ def main():
     assert cratedb_version and cratedb_url
 
     crash_version, crash_url = ensure_existing_crash_release(args.crash_version)
-    jdk_version_default = Version(12, 0, 1) if cratedb_version.major >= 4 else Version(11, 0, 1)
+    jdk_version_default = Version(13, 0, 0) if cratedb_version.major >= 4 else Version(12, 0, 1)
     jdk_version = args.jdk_version or jdk_version_default
     jdk_url, jdk_sha256 = jdk_url_and_sha(jdk_version)
     template = args.template or find_template_for_version(cratedb_version)


### PR DESCRIPTION
CrateDB already runs its tests for version 13 of java.

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
