### PR TITLE
Remove installing the IUS repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ ENV JAVA_HOME /opt/jdk-13.0.1
 RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /opt/jdk-13.0.1/lib/security/cacerts
 
 # install crate
-RUN yum install -y yum-utils https://centos7.iuscommunity.org/ius-release.rpm \
+RUN yum install -y yum-utils \
     && yum makecache \
-    && yum install -y python36u openssl \
+    && yum install -y python36 openssl \
     && yum clean all \
     && rm -rf /var/cache/yum \
     && curl -fSL -O https://cdn.crate.io/downloads/releases/crate-4.1.1.tar.gz \

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -21,9 +21,9 @@ ENV JAVA_HOME /opt/jdk-{{ JDK_VERSION }}
 RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /opt/jdk-{{ JDK_VERSION }}/lib/security/cacerts
 
 # install crate
-RUN yum install -y yum-utils https://centos7.iuscommunity.org/ius-release.rpm \
+RUN yum install -y yum-utils \
     && yum makecache \
-    && yum install -y python36u openssl \
+    && yum install -y python36 openssl \
     && yum clean all \
     && rm -rf /var/cache/yum \
     && curl -fSL -O {{ CRATE_URL }} \


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

IUS (Inline with Upstream Stable) is a yum repository with newer versions of
some software for Centos. However, when adding this repo on the ARM architecture,
we get the following error:

```
https://repo.ius.io/7/aarch64/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found
```

Tthe IUS repo has no repodata for aarch64 packages, which would suggest that it isn't
supported on that architecture.

The one package we were relying on the IUS repository for was python36u. However, the
standard yum repositories have a python36 package, and both of these packages install
the same python version (3.6.8).

This commit therefore removes the dependency on python36u, switching it to the standard
python36 repository and removing the need to add the IUS repo. This now builds as expected
on linux/arm64.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
