### PR TITLE
Test for presence of UseG1GC instead of UseConcMarkSweepGC

### DIFF
--- a/tests/itests.py
+++ b/tests/itests.py
@@ -196,7 +196,7 @@ class CrateJavaOptsTest(DockerBaseTestCase):
         # crate docker java options
         self.assertTrue('+UnlockExperimentalVMOptions' in opts)
         # default java options
-        self.assertTrue('+UseConcMarkSweepGC' in opts)
+        self.assertTrue('+UseG1GC' in opts)
         self.assertTrue('+DisableExplicitGC' in opts)
 
         # check -D process arguments


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Since CrateDB 4.1, we now use G1GC, which means we no longer need to test for the
presence of the UseConcMarkSweepGC Java opt.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
