### PR TITLE
Do not download JDK to run CrateDB.

### DIFF
--- a/Dockerfile_4.1.j2
+++ b/Dockerfile_4.1.j2
@@ -10,6 +10,16 @@ FROM centos:7
 
 RUN groupadd crate && useradd -u 1000 -g crate -d /crate crate
 
+RUN curl --retry 8 -o /openjdk.tar.gz {{ JDK_URL }} \
+    && echo "{{ JDK_SHA256 }} */openjdk.tar.gz" | sha256sum -c - \
+    && tar -C /opt -zxf /openjdk.tar.gz \
+    && rm /openjdk.tar.gz
+
+ENV JAVA_HOME /opt/jdk-{{ JDK_VERSION }}
+
+# REF: https://github.com/elastic/elasticsearch-docker/issues/171
+RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /opt/jdk-{{ JDK_VERSION }}/lib/security/cacerts
+
 # install crate
 RUN yum install -y yum-utils \
     && yum makecache \


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

CrateDB >= 4.2 runs with the budled JDK. See https://github.com/crate/crate/pull/9746

Related https://github.com/crate/crate/issues/9754


Tested manually. 
We have to follow up on the test suite here such as tests run only against rendered Dockerfile.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
