### PR TITLE
Fix yum within CrateDB's docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN yum install -y yum-utils \
     && tar -xf crate-4.1.5.tar.gz -C /crate --strip-components=1 \
     && rm crate-4.1.5.tar.gz \
     && ln -sf /usr/bin/python3.6 /usr/bin/python3 \
-    && ln -sf /usr/bin/python3.6 /usr/bin/python
+    && ln -sf /usr/bin/python3.6 /usr/bin/python \
+    && sed -i '1s/\/usr\/bin\/python/\/usr\/bin\/python2/g' /usr/bin/yum
 
 # install crash
 RUN curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_0.24.2 \

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -25,7 +25,8 @@ RUN yum install -y yum-utils \
     && tar -xf {{ CRATE_TAR_GZ }} -C /crate --strip-components=1 \
     && rm {{ CRATE_TAR_GZ }} \
     && ln -sf /usr/bin/python3.6 /usr/bin/python3 \
-    && ln -sf /usr/bin/python3.6 /usr/bin/python
+    && ln -sf /usr/bin/python3.6 /usr/bin/python \
+    && sed -i '1s/\/usr\/bin\/python/\/usr\/bin\/python2/g' /usr/bin/yum
 
 # install crash
 RUN curl -fSL -O {{ CRASH_URL }} \

--- a/Dockerfile_4.1.j2
+++ b/Dockerfile_4.1.j2
@@ -35,7 +35,8 @@ RUN yum install -y yum-utils \
     && tar -xf {{ CRATE_TAR_GZ }} -C /crate --strip-components=1 \
     && rm {{ CRATE_TAR_GZ }} \
     && ln -sf /usr/bin/python3.6 /usr/bin/python3 \
-    && ln -sf /usr/bin/python3.6 /usr/bin/python
+    && ln -sf /usr/bin/python3.6 /usr/bin/python \
+    && sed -i '1s/\/usr\/bin\/python/\/usr\/bin\/python2/g' /usr/bin/yum
 
 # install crash
 RUN curl -fSL -O {{ CRASH_URL }} \


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Yum, the CentOS package manager, requires Python 2. In the course
of installing Python 3.6, we symlink the default system Python from
Python 2 to 3.

The shebang at the top of yum's main file is '!#/usr/bin/python',
which now references the 3.6 installation. This commit replaces
the shebang at the top of yum's script to point, instead, to
'!#/usr/bin/python2'.

@MarkusH I'm not entirely sure how I feel about this. :scream: Would you have any other suggestions?