### PR TITLE
Remove Python3 -> Python symlink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ RUN yum install -y yum-utils \
     && rm -rf "$GNUPGHOME" crate-4.1.5.tar.gz.asc \
     && tar -xf crate-4.1.5.tar.gz -C /crate --strip-components=1 \
     && rm crate-4.1.5.tar.gz \
-    && ln -sf /usr/bin/python3.6 /usr/bin/python3 \
-    && ln -sf /usr/bin/python3.6 /usr/bin/python
+    && ln -sf /usr/bin/python3.6 /usr/bin/python3
 
 # install crash
 RUN curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_0.24.2 \

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -24,8 +24,7 @@ RUN yum install -y yum-utils \
     && rm -rf "$GNUPGHOME" {{ CRATE_TAR_GZ }}.asc \
     && tar -xf {{ CRATE_TAR_GZ }} -C /crate --strip-components=1 \
     && rm {{ CRATE_TAR_GZ }} \
-    && ln -sf /usr/bin/python3.6 /usr/bin/python3 \
-    && ln -sf /usr/bin/python3.6 /usr/bin/python
+    && ln -sf /usr/bin/python3.6 /usr/bin/python3
 
 # install crash
 RUN curl -fSL -O {{ CRASH_URL }} \

--- a/Dockerfile_4.1.j2
+++ b/Dockerfile_4.1.j2
@@ -34,8 +34,7 @@ RUN yum install -y yum-utils \
     && rm -rf "$GNUPGHOME" {{ CRATE_TAR_GZ }}.asc \
     && tar -xf {{ CRATE_TAR_GZ }} -C /crate --strip-components=1 \
     && rm {{ CRATE_TAR_GZ }} \
-    && ln -sf /usr/bin/python3.6 /usr/bin/python3 \
-    && ln -sf /usr/bin/python3.6 /usr/bin/python
+    && ln -sf /usr/bin/python3.6 /usr/bin/python3
 
 # install crash
 RUN curl -fSL -O {{ CRASH_URL }} \


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This symlink breaks yum, as yum expects the default system python
to be python 2. The symlink was initially required to run crash,
as it's shebang previously was ambiguous about which python version
it needs. With https://github.com/crate/crash/commit/fde0770cfc798227378b0223c0cda9e1153ac3f6
this symlink is no longer required.