### PR TITLE
GH: Use docker/setup-buildx-action@v1 for multi-platform builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,30 +10,35 @@ jobs:
         arch: [linux/amd64, linux/arm64]
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python 3.7
         uses: actions/setup-python@v1
         with:
           python-version: 3.7
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         id: buildx
-        uses: crazy-max/ghaction-docker-buildx@v3
-        with:
-          buildx-version: latest
-          qemu-version: latest
+        uses: docker/setup-buildx-action@v1
+
       - name: Update CrateDB docker image version
         run: |
           python -m pip install --upgrade pip --quiet
           pip install -r requirements.txt --quiet
           VERSION=$(curl -s https://crate.io/versions.json | grep crate_testing | tr -d '" ' | cut -d ":" -f2)
           ./update.py --cratedb-version ${VERSION} > Dockerfile
+
       - name: Build CrateDB docker image
         run: |
           docker buildx build \
             --platform ${{ matrix.arch }} \
             --load \
             --file ./Dockerfile . \
-            --tag crate/crate:$(echo ${{ matrix.arch }} | cut -d "/" -f2)
+            --tag crate/crate:ci_test
+
       - name: Run Docker official images tests
         run: |
           git clone https://github.com/docker-library/official-images.git ~/official-images
-          ~/official-images/test/run.sh crate/crate:$(echo ${{ matrix.arch }} | cut -d "/" -f2)
+          ~/official-images/test/run.sh crate/crate:ci_test


### PR DESCRIPTION
`crazy-max/ghaction-docker-buildx` is deprecated and superseded by
the official docker action `docker/setup-buildx-action`.