### PR TITLE
Handle empty version arguments in update.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,5 +26,4 @@ jobs:
         run: |
           VERSION=$(curl -s https://crate.io/versions.json | grep crate_testing | tr -d '" ' | cut -d ":" -f2)
           ./update.py --cratedb-version ${VERSION} > Dockerfile
-          sysctl -w vm.max_map_count=262144
           PATH_TO_IMAGE=. zope-testrunner --path . -s tests --color

--- a/update.py
+++ b/update.py
@@ -30,7 +30,7 @@ class Version(NamedTuple):
 
     @classmethod
     def parse(cls, s: str):
-        if s is None:
+        if not s:
             return None
         parts = s.split('.', maxsplit=2)
         snapshot_parts = parts[2].split('-', maxsplit=1)


### PR DESCRIPTION
Jenkins should be allowed to use `--crash-version ""` to use the latest
version.