### PR TITLE
Update CentOS 7 baseline image

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,6 +5,29 @@ Contributing
 Thank you for your interest in contributing.
 
 Please see the CrateDB `contribution guide`_ for more information. Everything in
-the CrateDB contribution guide applies to this repository.
+the CrateDB contribution guide also applies to this repository.
+
+
+Usage
+=====
+
+In order to create a Dockerfile for local testing and create a container image,
+use those commands::
+
+    export CRATEDB_VERSION=4.8.0
+    python3 update.py --cratedb-version ${CRATEDB_VERSION} > Dockerfile.probe
+    docker build --file Dockerfile.probe --tag local/crate:${CRATEDB_VERSION} .
+
+To introspect the software versions available, run::
+
+    docker run -it --rm local/crate:${CRATEDB_VERSION} crate -v
+    docker run -it --rm local/crate:${CRATEDB_VERSION} crash --version
+
+For starting an instance of CrateDB and connecting to it, run::
+
+    docker run -it --rm --name=cratedb --publish=4200:4200 --publish=5432:5432 local/crate:${CRATEDB_VERSION}
+    docker exec -it cratedb crash
+
+
 
 .. _contribution guide: https://github.com/crate/crate/blob/master/CONTRIBUTING.rst

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -7,14 +7,18 @@
 
 FROM centos:7
 
-RUN groupadd crate && useradd -u 1000 -g crate -d /crate crate
-
-# install crate
-RUN yum install -y yum-utils \
+# Install prerequisites and package updates and clean up repository indexes again
+RUN yum install -y yum-utils deltarpm \
     && yum makecache \
-    && yum install -y python36 openssl \
+    && yum install -y python3 openssl \
+    && yum upgrade -y \
+    && pip3 install "pip>=19,<19.3" --upgrade \
     && yum clean all \
-    && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum
+
+# Install CrateDB
+RUN groupadd crate \
+    && useradd -u 1000 -g crate -d /crate crate \
     && export PLATFORM="$( \
         case $(uname --m) in \
             x86_64)  echo x64_linux ;; \
@@ -28,10 +32,9 @@ RUN yum install -y yum-utils \
     && gpg --batch --verify {{ CRATE_TAR_GZ }}.asc {{ CRATE_TAR_GZ }} \
     && rm -rf "$GNUPGHOME" {{ CRATE_TAR_GZ }}.asc \
     && tar -xf {{ CRATE_TAR_GZ }} -C /crate --strip-components=1 \
-    && rm {{ CRATE_TAR_GZ }} \
-    && ln -sf /usr/bin/python3.6 /usr/bin/python3
+    && rm {{ CRATE_TAR_GZ }}
 
-# install crash
+# Install crash
 RUN curl -fSL -O {{ CRASH_URL }} \
     && curl -fSL -O {{ CRASH_URL }}.asc \
     && export GNUPGHOME="$(mktemp -d)" \


### PR DESCRIPTION
Hi.

This patch assures package updates are applied to the CentOS 7 baseline image in order to get the latest security updates.

With kind regards,
Andreas.