### PR TITLE
Stop pinning the `pip` package, essentially updating to the most recent 21.3 patch release

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,8 @@
+ignore:
+
+  # Two vulnerabilities for pip 9.0.3.
+  # Fixed with `pip3 install --upgrade pip`.
+  # Grype would still complain, because it picks up the RPM-installed `python3-pip` package.
+  # It can't be removed, because `python3` has a dependency on it.
+  - vulnerability: GHSA-gpvv-69j7-gwj8  # CVE-2019-20916
+  - vulnerability: GHSA-5xp3-jfq3-5q8x  # CVE-2021-3572

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,7 +14,7 @@ Usage
 In order to create a Dockerfile for local testing and create a container image,
 use those commands::
 
-    export CRATEDB_VERSION=4.8.0
+    export CRATEDB_VERSION=5.0.0
     python3 update.py --cratedb-version ${CRATEDB_VERSION} > Dockerfile.probe
     docker build --file Dockerfile.probe --tag local/crate:${CRATEDB_VERSION} .
 
@@ -28,6 +28,9 @@ For starting an instance of CrateDB and connecting to it, run::
     docker run -it --rm --name=cratedb --publish=4200:4200 --publish=5432:5432 local/crate:${CRATEDB_VERSION}
     docker exec -it cratedb crash
 
+Run a vulnerability scan on the resulting image::
 
+    grype --config .grype.yaml --only-fixed --fail-on medium local/crate:${CRATEDB_VERSION}
+    trivy image --severity "CRITICAL,HIGH,MEDIUM" --ignore-unfixed --exit-code 1 local/crate:${CRATEDB_VERSION}
 
 .. _contribution guide: https://github.com/crate/crate/blob/master/CONTRIBUTING.rst

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -12,7 +12,7 @@ RUN yum install -y yum-utils deltarpm \
     && yum makecache \
     && yum install -y python3 openssl \
     && yum upgrade -y \
-    && pip3 install "pip>=19,<19.3" --upgrade \
+    && pip3 install --upgrade pip \
     && yum clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
Hi there,

@WalBeh notified us about some vulnerability indications from tools like [Grype] and [Trivy]. Thank you.

With this patch, 94cda2a0e installs a more recent version of `pip`. 1043921ab9 adds information about how to use the `grype` and `trivy` programs on your own behalf.

References: GHSA-gpvv-69j7-gwj8, GHSA-5xp3-jfq3-5q8x

With kind regards,
Andreas.

[Grype]: https://github.com/anchore/grype
[Trivy]: https://github.com/aquasecurity/trivy
