### PR TITLE
Align Dockerfile for nightly builds with Dockerfile for GA builds

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,9 +14,16 @@ Usage
 In order to create a Dockerfile for local testing and create a container image,
 use those commands::
 
+    # Create Dockerfile for building a GA image
     export CRATEDB_VERSION=5.0.0
-    python3 update.py --cratedb-version ${CRATEDB_VERSION} > Dockerfile.probe
-    docker build --file Dockerfile.probe --tag local/crate:${CRATEDB_VERSION} .
+    python3 update.py --cratedb-version ${CRATEDB_VERSION} > Dockerfile-${CRATEDB_VERSION}
+
+    # Create Dockerfile for building a nightly image
+    export CRATEDB_VERSION=5.0.0-202207120003-fb24ad5
+    python3 update.py --cratedb-tarball https://cdn.crate.io/downloads/releases/nightly/crate-${CRATEDB_VERSION}.tar.gz > Dockerfile-${CRATEDB_VERSION}
+
+    # Build
+    docker build --file Dockerfile-${CRATEDB_VERSION} --tag local/crate:${CRATEDB_VERSION} .
 
 To introspect the software versions available, run::
 

--- a/Dockerfile_nightly.j2
+++ b/Dockerfile_nightly.j2
@@ -7,14 +7,18 @@
 
 FROM centos:7
 
-RUN groupadd crate && useradd -u 1000 -g crate -d /crate crate
-
-# install crate
-RUN yum install -y yum-utils \
+# Install prerequisites and package updates and clean up repository indexes again
+RUN yum install -y yum-utils deltarpm \
     && yum makecache \
-    && yum install -y python36 openssl \
+    && yum install -y python3 openssl \
+    && yum upgrade -y \
+    && pip3 install --upgrade pip \
     && yum clean all \
-    && rm -rf /var/cache/yum \
+    && rm -rf /var/cache/yum
+
+# Install CrateDB
+RUN groupadd crate \
+    && useradd -u 1000 -g crate -d /crate crate \
     && export CRATE_URL={{ CRATE_RELEASE_URL }}/{{ CRATE_TAR_GZ }} \
     && curl -fSL -O ${CRATE_URL} \
     && curl -fSL -O ${CRATE_URL}.asc \
@@ -23,10 +27,9 @@ RUN yum install -y yum-utils \
     && gpg --batch --verify {{ CRATE_TAR_GZ }}.asc {{ CRATE_TAR_GZ }} \
     && rm -rf "$GNUPGHOME" {{ CRATE_TAR_GZ }}.asc \
     && tar -xf {{ CRATE_TAR_GZ }} -C /crate --strip-components=1 \
-    && rm {{ CRATE_TAR_GZ }} \
-    && ln -sf /usr/bin/python3.6 /usr/bin/python3
+    && rm {{ CRATE_TAR_GZ }}
 
-# install crash
+# Install crash
 RUN curl -fSL -O {{ CRASH_URL }} \
     && curl -fSL -O {{ CRASH_URL }}.asc \
     && export GNUPGHOME="$(mktemp -d)" \


### PR DESCRIPTION
Hi.

This patch assures package updates are applied to the CentOS 7 baseline image in order to get the latest security updates. Essentially, it brings the gist of #195 and #200 also to the _nightly_ images.

I've tested the build process on my workstation as outlined within the documentation section, and it looks like it works well.

With kind regards,
Andreas.

/cc @WalBeh - thank you!
