### PR TITLE
Invoke `yum upgrade` before `yum install`

### DIFF
--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -10,8 +10,8 @@ FROM centos:7
 # Install prerequisites and package updates and clean up repository indexes again
 RUN yum install -y yum-utils deltarpm \
     && yum makecache \
-    && yum install -y python3 openssl \
     && yum upgrade -y \
+    && yum install -y python3 openssl \
     && pip3 install --upgrade pip \
     && yum clean all \
     && rm -rf /var/cache/yum

--- a/Dockerfile_nightly.j2
+++ b/Dockerfile_nightly.j2
@@ -10,8 +10,8 @@ FROM centos:7
 # Install prerequisites and package updates and clean up repository indexes again
 RUN yum install -y yum-utils deltarpm \
     && yum makecache \
-    && yum install -y python3 openssl \
     && yum upgrade -y \
+    && yum install -y python3 openssl \
     && pip3 install --upgrade pip \
     && yum clean all \
     && rm -rf /var/cache/yum


### PR DESCRIPTION
Dear @matriv,

this patch implements your suggestion from https://github.com/crate/docker-crate/pull/201#pullrequestreview-1035803773.

With kind regards,
Andreas.