### PR TITLE
Update tests/README. Docker Toolbox is a thing of the past.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,20 +1,3 @@
-CrateDB Docker Image
-Copyright 2013-2016 Crate.IO GmbH ("Crate")
-
-
-Licensed to CRATE Technology GmbH (referred to in this notice as "Crate")
-under one or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information regarding copyright
-ownership.
-
-Crate licenses this software to you under the Apache License, Version 2.0.
-However, if you have executed another commercial license agreement with
-Crate these terms will supersede the license and you may use the software
-solely pursuant to the terms of the relevant commercial agreement.
-
-
-=========================================================================
-
 
                                  Apache License
                            Version 2.0, January 2004
@@ -192,28 +175,3 @@ solely pursuant to the terms of the relevant commercial agreement.
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -1,53 +1,81 @@
 .. highlight: sh
 
+==============================
 Crate Docker Image Development
 ==============================
 
-Running Tests
--------------
 
-Create a virtual environment::
+Prerequisites
+=============
 
-  >>> python3 -m venv .venv
+For invoking the next steps, you will need to have Docker and Python installed
+on your computer.
 
-Then activate it::
+First, create a virtual environment and install the Python dependencies::
 
-  >>> source .venv/bin/activate
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install -r requirements.txt
 
-Now use pip to install the dependencies::
 
-  >>> pip install -r requirements.txt
+Configuring ``vm.max_map_count``
+================================
 
-The tests require `Docker <https://www.docker.com>`_ version `1.10.x`
-with API version `1.22` to be installed on the local machine::
+It is important that the system-wide ``vm.max_map_count`` setting is configured
+to a higher value than the default one, see also `adjust system limits on
+Linux`_. On most default installations of Docker Desktop, it is already
+configured to ``262144`` today, but it was ``65530`` for previous releases.
 
-  >>> docker version
-  Client:
-   Version:      1.10.3
-   API version:  1.22
-   Go version:   go1.5.3
-   Git commit:   20f81dd
-   Built:        Thu Mar 10 21:49:11 2016
-   OS/Arch:      darwin/amd64
-  Server:
-   Version:      1.10.3
-   API version:  1.22
-   Go version:   go1.5.3
-   Git commit:   20f81dd
-   Built:        Thu Mar 10 21:49:11 2016
-   OS/Arch:      linux/amd64
+You can easily check this on your machine by running::
 
-For OSX you would need to install `Docker Toolbox <https://www.docker.com/products/docker-toolbox>`_
-and initialize the Docker environment using the Quickstart Terminal::
+    docker run --rm -it busybox sysctl vm.max_map_count
 
-  >>> /bin/bash -c "/Applications/Docker/Docker\ Quickstart\ Terminal.app/Contents/Resources/Scripts/start.sh"
+If you see a lower value, you should adjust the setting correspondingly.
 
-For CrateDB >= 1.2 you would need to change the following setting in your docker machine::
 
-  >>> docker-machine ssh default "sudo sysctl -w vm.max_map_count=262144"
+Configuration on Linux
+----------------------
+
+- Ad hoc: Invoke ``sudo sysctl -w vm.max_map_count=262144``.
+- Persistent: Add ``vm.max_map_count = 262144`` to ``/etc/sysctl.conf`` or
+  ``/etc/sysctl.d/``, then invoke ``sysctl --system``, or reboot.
+
+
+Configuration on macOS
+----------------------
+
+Ad hoc::
+
+    docker run -it --privileged --pid=host debian nsenter -t 1 -m -u -n -i sh
+    sysctl -w vm.max_map_count=262144
+
+
+Configuration on Windows
+------------------------
+
+Depending on the Docker backend you are using on Windows (WSL2 vs. Hyper-V),
+the setting may show a default value of ``65530``, or ``262144``.
+
+In order to adjust the value, add this snippet to ``%userprofile%\.wslconfig``,
+for example ``C:\Users\<username>\.wslconfig``, invoke ``wsl --shutdown``, and
+restart::
+
+    [wsl2]
+    kernelCommandLine = "sysctl.vm.max_map_count=262144"
+
+Please note that your WSL Linux machine must be running Linux kernel release
+5.8 or higher in order to use this recipe.
+
+
+Running tests
+=============
 
 To run the tests::
 
-  >>> PATH_TO_IMAGE=amd64/crate zope-testrunner --path . -s tests --color
+    PATH_TO_IMAGE=. zope-testrunner --path . -s tests --color
 
 Where ``PATH_TO_IMAGE`` is a root-relative path to a folder with a Dockerfile.
+
+
+.. _adjust system limits on Linux: https://crate.io/docs/crate/howtos/en/latest/admin/bootstrap-checks.html#linux
+


### PR DESCRIPTION
Nothing significant. Just updates some outdated documentation and software versions, and aligns the LICENSE.txt file with the one from CrateDB itself.