### PR TITLE
Use AlmaLinux 9 as base image

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,8 +1,0 @@
-ignore:
-
-  # Two vulnerabilities for pip 9.0.3.
-  # Fixed with `pip3 install --upgrade pip`.
-  # Grype would still complain, because it picks up the RPM-installed `python3-pip` package.
-  # It can't be removed, because `python3` has a dependency on it.
-  - vulnerability: GHSA-gpvv-69j7-gwj8  # CVE-2019-20916
-  - vulnerability: GHSA-5xp3-jfq3-5q8x  # CVE-2021-3572

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -37,7 +37,7 @@ For starting an instance of CrateDB and connecting to it, run::
 
 Run a vulnerability scan on the resulting image::
 
-    grype --config .grype.yaml --only-fixed --fail-on medium local/crate:${CRATEDB_VERSION}
+    grype --only-fixed --fail-on medium local/crate:${CRATEDB_VERSION}
     trivy image --severity "CRITICAL,HIGH,MEDIUM" --ignore-unfixed --exit-code 1 local/crate:${CRATEDB_VERSION}
 
 .. _contribution guide: https://github.com/crate/crate/blob/master/CONTRIBUTING.rst

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -10,7 +10,6 @@ FROM almalinux:9
 # Install prerequisites and package updates and clean up repository indexes again
 RUN yum install -y yum-utils \
     && yum makecache \
-    && yum upgrade -y \
     && yum install -y python3 python3-pip openssl \
     && yum clean all \
     && rm -rf /var/cache/yum

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -5,14 +5,13 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM centos:7
+FROM almalinux:9
 
 # Install prerequisites and package updates and clean up repository indexes again
-RUN yum install -y yum-utils deltarpm \
+RUN yum install -y yum-utils \
     && yum makecache \
     && yum upgrade -y \
-    && yum install -y python3 openssl \
-    && pip3 install --upgrade pip \
+    && yum install -y python3 python3-pip openssl \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/Dockerfile_5.0.j2
+++ b/Dockerfile_5.0.j2
@@ -1,0 +1,80 @@
+{%- set CRATE_TAR_GZ   = "crate-{}.tar.gz".format(CRATE_VERSION) -%}
+## -*- docker-image-name: "docker-crate" -*-
+#
+# Crate Dockerfile
+# https://github.com/crate/docker-crate
+#
+
+FROM centos:7
+
+# Install prerequisites and package updates and clean up repository indexes again
+RUN yum install -y yum-utils deltarpm \
+    && yum makecache \
+    && yum upgrade -y \
+    && yum install -y python3 openssl \
+    && pip3 install --upgrade pip \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+# Install CrateDB
+RUN groupadd crate \
+    && useradd -u 1000 -g crate -d /crate crate \
+    && export PLATFORM="$( \
+        case $(uname --m) in \
+            x86_64)  echo x64_linux ;; \
+            aarch64) echo aarch64_linux ;; \
+        esac)" \
+    && export CRATE_URL={{ CRATE_RELEASE_URL }}/${PLATFORM}/{{ CRATE_TAR_GZ }} \
+    && curl -fSL -O ${CRATE_URL} \
+    && curl -fSL -O ${CRATE_URL}.asc \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
+    && gpg --batch --verify {{ CRATE_TAR_GZ }}.asc {{ CRATE_TAR_GZ }} \
+    && rm -rf "$GNUPGHOME" {{ CRATE_TAR_GZ }}.asc \
+    && tar -xf {{ CRATE_TAR_GZ }} -C /crate --strip-components=1 \
+    && rm {{ CRATE_TAR_GZ }}
+
+# Install crash
+RUN curl -fSL -O {{ CRASH_URL }} \
+    && curl -fSL -O {{ CRASH_URL }}.asc \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
+    && gpg --batch --verify crash_standalone_{{ CRASH_VERSION }}.asc crash_standalone_{{ CRASH_VERSION }} \
+    && rm -rf "$GNUPGHOME" crash_standalone_{{ CRASH_VERSION }}.asc \
+    && mv crash_standalone_{{ CRASH_VERSION }} /usr/local/bin/crash \
+    && chmod +x /usr/local/bin/crash
+
+ENV PATH /crate/bin:$PATH
+# Default heap size for Docker, can be overwritten by args
+ENV CRATE_HEAP_SIZE 512M
+
+RUN mkdir -p /data/data /data/log
+
+VOLUME /data
+
+WORKDIR /data
+
+# http: 4200 tcp
+# transport: 4300 tcp
+# postgres protocol ports: 5432 tcp
+EXPOSE 4200 4300 5432
+
+# These COPY commands have been moved before the last one due to the following issues:
+# https://github.com/moby/moby/issues/37965#issuecomment-448926448
+# https://github.com/moby/moby/issues/38866
+COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
+COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
+
+LABEL maintainer="Crate.io <office@crate.io>" \
+    org.opencontainers.image.created="{{ BUILD_TIMESTAMP }}" \
+    org.opencontainers.image.title="crate" \
+    org.opencontainers.image.description="CrateDB is a distributed SQL database that handles massive amounts of machine data in real-time." \
+    org.opencontainers.image.url="https://crate.io/products/cratedb/" \
+    org.opencontainers.image.source="https://github.com/crate/docker-crate" \
+    org.opencontainers.image.vendor="Crate.io" \
+    org.opencontainers.image.version="{{ CRATE_VERSION }}"
+
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["crate"]

--- a/Dockerfile_5.1.j2
+++ b/Dockerfile_5.1.j2
@@ -1,0 +1,80 @@
+{%- set CRATE_TAR_GZ   = "crate-{}.tar.gz".format(CRATE_VERSION) -%}
+## -*- docker-image-name: "docker-crate" -*-
+#
+# Crate Dockerfile
+# https://github.com/crate/docker-crate
+#
+
+FROM centos:7
+
+# Install prerequisites and package updates and clean up repository indexes again
+RUN yum install -y yum-utils deltarpm \
+    && yum makecache \
+    && yum upgrade -y \
+    && yum install -y python3 openssl \
+    && pip3 install --upgrade pip \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+# Install CrateDB
+RUN groupadd crate \
+    && useradd -u 1000 -g crate -d /crate crate \
+    && export PLATFORM="$( \
+        case $(uname --m) in \
+            x86_64)  echo x64_linux ;; \
+            aarch64) echo aarch64_linux ;; \
+        esac)" \
+    && export CRATE_URL={{ CRATE_RELEASE_URL }}/${PLATFORM}/{{ CRATE_TAR_GZ }} \
+    && curl -fSL -O ${CRATE_URL} \
+    && curl -fSL -O ${CRATE_URL}.asc \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
+    && gpg --batch --verify {{ CRATE_TAR_GZ }}.asc {{ CRATE_TAR_GZ }} \
+    && rm -rf "$GNUPGHOME" {{ CRATE_TAR_GZ }}.asc \
+    && tar -xf {{ CRATE_TAR_GZ }} -C /crate --strip-components=1 \
+    && rm {{ CRATE_TAR_GZ }}
+
+# Install crash
+RUN curl -fSL -O {{ CRASH_URL }} \
+    && curl -fSL -O {{ CRASH_URL }}.asc \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
+    && gpg --batch --verify crash_standalone_{{ CRASH_VERSION }}.asc crash_standalone_{{ CRASH_VERSION }} \
+    && rm -rf "$GNUPGHOME" crash_standalone_{{ CRASH_VERSION }}.asc \
+    && mv crash_standalone_{{ CRASH_VERSION }} /usr/local/bin/crash \
+    && chmod +x /usr/local/bin/crash
+
+ENV PATH /crate/bin:$PATH
+# Default heap size for Docker, can be overwritten by args
+ENV CRATE_HEAP_SIZE 512M
+
+RUN mkdir -p /data/data /data/log
+
+VOLUME /data
+
+WORKDIR /data
+
+# http: 4200 tcp
+# transport: 4300 tcp
+# postgres protocol ports: 5432 tcp
+EXPOSE 4200 4300 5432
+
+# These COPY commands have been moved before the last one due to the following issues:
+# https://github.com/moby/moby/issues/37965#issuecomment-448926448
+# https://github.com/moby/moby/issues/38866
+COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
+COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
+
+LABEL maintainer="Crate.io <office@crate.io>" \
+    org.opencontainers.image.created="{{ BUILD_TIMESTAMP }}" \
+    org.opencontainers.image.title="crate" \
+    org.opencontainers.image.description="CrateDB is a distributed SQL database that handles massive amounts of machine data in real-time." \
+    org.opencontainers.image.url="https://crate.io/products/cratedb/" \
+    org.opencontainers.image.source="https://github.com/crate/docker-crate" \
+    org.opencontainers.image.vendor="Crate.io" \
+    org.opencontainers.image.version="{{ CRATE_VERSION }}"
+
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["crate"]

--- a/Dockerfile_nightly.j2
+++ b/Dockerfile_nightly.j2
@@ -10,7 +10,6 @@ FROM almalinux:9
 # Install prerequisites and package updates and clean up repository indexes again
 RUN yum install -y yum-utils \
     && yum makecache \
-    && yum upgrade -y \
     && yum install -y python3 python3-pip openssl \
     && yum clean all \
     && rm -rf /var/cache/yum

--- a/Dockerfile_nightly.j2
+++ b/Dockerfile_nightly.j2
@@ -5,14 +5,13 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM centos:7
+FROM almalinux:9
 
 # Install prerequisites and package updates and clean up repository indexes again
-RUN yum install -y yum-utils deltarpm \
+RUN yum install -y yum-utils \
     && yum makecache \
     && yum upgrade -y \
-    && yum install -y python3 openssl \
-    && pip3 install --upgrade pip \
+    && yum install -y python3 python3-pip openssl \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/tests/itests.py
+++ b/tests/itests.py
@@ -272,4 +272,4 @@ class TarballRemovedTest(DockerBaseTestCase):
         self.wait_for_cluster()
         id = self.cli.exec_create('crate', 'ls -la /crate-*')
         res = self.cli.exec_start(id['Id'])
-        self.assertEqual(b"ls: cannot access '/crate-*': No such file or directory\n", res)
+        self.assertEqual(b'ls: cannot access /crate-*: No such file or directory\n', res)

--- a/tests/itests.py
+++ b/tests/itests.py
@@ -272,4 +272,4 @@ class TarballRemovedTest(DockerBaseTestCase):
         self.wait_for_cluster()
         id = self.cli.exec_create('crate', 'ls -la /crate-*')
         res = self.cli.exec_start(id['Id'])
-        self.assertEqual(b'ls: cannot access /crate-*: No such file or directory\n', res)
+        self.assertEqual(b"ls: cannot access '/crate-*': No such file or directory\n", res)


### PR DESCRIPTION
Hi there,

regarding the quest for a new base image (see #205), I am gravitating towards [AlmaLinux].

>  AlmaLinux OS is an open-source, community-driven Linux operating system that fills the gap left by the discontinuation of the CentOS Linux stable release. AlmaLinux OS is a 1:1 binary compatible clone of RHEL® guided and built by the community.

- The walkthrough within the [CONTRIBUTING] file has been exercised successfully.
- The total image size will be reduced from 820MB to 630MB.
- Vulnerability scanners like Grype or Trivy will not complain about any security issues.

With kind regards,
Andreas.

[AlmaLinux]: https://almalinux.org/
[CONTRIBUTING]: https://github.com/crate/docker-crate/blob/053b7a096b5b9e268a75d303d5f7c018998b0516/CONTRIBUTING.rst

/cc @WalBeh 