### PR TITLE
CI: Use most recent versions of GitHub Action recipes. Use Python 3.10.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,19 +9,19 @@ jobs:
       matrix:
         arch: [linux/amd64, linux/arm64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v1
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: "3.10"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Update CrateDB docker image version
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+      - name: Set up Python
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install requirements
         run: python -m pip install -r ./requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,9 @@
+__pycache__
 *.pyc
 *.pyo
 bin/
 parts/
 .installed.cfg
-
 .idea/
-
 .venv/
-
 .mypy_cache/


### PR DESCRIPTION
Hi there,

this patch has been separated from #203. It only brings the GHA workflow definitions up to speed.

With kind regards,
Andreas.