### PR TITLE
Increase default value for `CRATE_HEAP_SIZE` from 512M to 2G

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN curl -fSL -O https://cdn.crate.io/downloads/releases/crash_standalone_0.28.0
 
 ENV PATH /crate/bin:$PATH
 # Default heap size for Docker, can be overwritten by args
-ENV CRATE_HEAP_SIZE 512M
+ENV CRATE_HEAP_SIZE 2G
 
 RUN mkdir -p /data/data /data/log
 

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -46,7 +46,7 @@ RUN curl -fSL -O {{ CRASH_URL }} \
 
 ENV PATH /crate/bin:$PATH
 # Default heap size for Docker, can be overwritten by args
-ENV CRATE_HEAP_SIZE 512M
+ENV CRATE_HEAP_SIZE 2G
 
 RUN mkdir -p /data/data /data/log
 

--- a/Dockerfile_nightly.j2
+++ b/Dockerfile_nightly.j2
@@ -41,7 +41,7 @@ RUN curl -fSL -O {{ CRASH_URL }} \
 
 ENV PATH /crate/bin:$PATH
 # Default heap size for Docker, can be overwritten by args
-ENV CRATE_HEAP_SIZE 512M
+ENV CRATE_HEAP_SIZE 2G
 
 RUN mkdir -p /data/data /data/log
 


### PR DESCRIPTION
Hi there,

the default setting of 512M for `CRATE_HEAP_SIZE` was defined four years ago. I think it is fine to increase that value to 2G today, in order to provide users a better default experience.

On the other hand, I will also be happy to learn if you think it is a bad idea.

With kind regards,
Andreas.

Reference: #208
