### PR TITLE
Replace dir `/data` with `/tmp/crate_data`

### DIFF
--- a/tests/itests.py
+++ b/tests/itests.py
@@ -207,12 +207,18 @@ class CrateJavaOptsTest(DockerBaseTestCase):
 
 
 class MountedDataDirectoryTest(DockerBaseTestCase):
+    # Use a directory under `/tmp` for this test to satisfy Docker
+    # on Mac, which wouldn't allow dirs like `/data`, as the dirs
+    # used must be defined as shared resources in
+    # Preferences->Resources->File sharing, and `/tmp` is set there
+    # by default
+
     """
-    docker run --volume $(mktemp -d):/data crate
+    docker run --volume $(mktemp -d):/tmp/crate_data crate
     """
 
     VOLUMES = {
-        '/data': {
+        '/tmp/crate_data': {
             'bind': mkdtemp(),
             'mode': 'rw',
         }
@@ -230,7 +236,7 @@ class MountedDataDirectoryTest(DockerBaseTestCase):
         self.assertEqual(b'blobs\ndata\nlog\n', res)
 
     def tearDown(self):
-        rmtree(self.VOLUMES['/data']['bind'])
+        rmtree(self.VOLUMES['/tmp/crate_data']['bind'])
         super().tearDown()
 
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Recent docker installtion on Mac doesn't allow to use `/data`, therefore replace it with `/tmp/crate_data` since `/tmp` is already shared by docker desktop (Preferences->Resources->File sharing)

Fixes: #212


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
