### PR TITLE
Remove explicit upgrade of `openssl` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM almalinux:9
 # Install prerequisites and package updates and clean up repository indexes again
 RUN yum install -y yum-utils \
     && yum makecache \
-    && yum install -y python3 python3-pip openssl \
+    && yum install -y python3 python3-pip \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -10,7 +10,7 @@ FROM almalinux:9
 # Install prerequisites and package updates and clean up repository indexes again
 RUN yum install -y yum-utils \
     && yum makecache \
-    && yum install -y python3 python3-pip openssl \
+    && yum install -y python3 python3-pip \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/Dockerfile_nightly.j2
+++ b/Dockerfile_nightly.j2
@@ -10,7 +10,7 @@ FROM almalinux:9
 # Install prerequisites and package updates and clean up repository indexes again
 RUN yum install -y yum-utils \
     && yum makecache \
-    && yum install -y python3 python3-pip openssl \
+    && yum install -y python3 python3-pip \
     && yum clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

The `openssl` packages provides the following files:
```
sh-5.1# repoquery --list openssl
Last metadata expiration check: 0:00:06 ago on Tue Mar 14 13:24:59 2023.
/usr/bin/make-dummy-cert
/usr/bin/openssl
/usr/bin/renew-dummy-cert
/usr/lib/.build-id
/usr/lib/.build-id/84
/usr/lib/.build-id/84/1bf9c21ad5c7f2ec794159ff8ef2c11f78d498
/usr/share/doc/openssl
/usr/share/doc/openssl/Makefile.certificate
... [man pages/other READMEs skipped]
```

None of these files appear to be used when building the image.

Open question: Is any cloud-related component depending on it?

## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
