### PR TITLE
Fix tests after switch to AlmaLinux 9

### DIFF
--- a/tests/itests.py
+++ b/tests/itests.py
@@ -272,4 +272,4 @@ class TarballRemovedTest(DockerBaseTestCase):
         self.wait_for_cluster()
         id = self.cli.exec_create('crate', 'ls -la /crate-*')
         res = self.cli.exec_start(id['Id'])
-        self.assertEqual(b'ls: cannot access /crate-*: No such file or directory\n', res)
+        self.assertEqual(b"ls: cannot access '/crate-*': No such file or directory\n", res)


### PR DESCRIPTION
This patch brings in 0ed7191 again after the observation reported at https://github.com/crate/docker-crate/pull/218#issuecomment-1468200228. Apparently, this spot of AlmaLinux is flaky.