### PR TITLE
Switch base image to `almalinux:9-minimal`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM almalinux:9
 # Install prerequisites and package updates and clean up repository indexes again
 RUN yum install -y yum-utils \
     && yum makecache \
-    && yum install -y python3 python3-pip openssl \
+    && yum install -y python3 python3-pip \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,11 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM almalinux:9
+FROM almalinux:9-minimal
 
-# Install prerequisites and package updates and clean up repository indexes again
-RUN yum install -y yum-utils \
-    && yum makecache \
-    && yum install -y python3 python3-pip \
-    && yum clean all \
+# Install prerequisites and clean up repository indexes again
+RUN microdnf install --nodocs --assumeyes gzip python3 shadow-utils tar \
+    && microdnf clean all \
     && rm -rf /var/cache/yum
 
 # Install CrateDB

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -10,7 +10,7 @@ FROM almalinux:9
 # Install prerequisites and package updates and clean up repository indexes again
 RUN yum install -y yum-utils \
     && yum makecache \
-    && yum install -y python3 python3-pip openssl \
+    && yum install -y python3 python3-pip \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -5,13 +5,11 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM almalinux:9
+FROM almalinux:9-minimal
 
-# Install prerequisites and package updates and clean up repository indexes again
-RUN yum install -y yum-utils \
-    && yum makecache \
-    && yum install -y python3 python3-pip \
-    && yum clean all \
+# Install prerequisites and clean up repository indexes again
+RUN microdnf install --nodocs --assumeyes gzip python3 shadow-utils tar \
+    && microdnf clean all \
     && rm -rf /var/cache/yum
 
 # Install CrateDB

--- a/Dockerfile_5.2.j2
+++ b/Dockerfile_5.2.j2
@@ -1,0 +1,78 @@
+{%- set CRATE_TAR_GZ   = "crate-{}.tar.gz".format(CRATE_VERSION) -%}
+## -*- docker-image-name: "docker-crate" -*-
+#
+# Crate Dockerfile
+# https://github.com/crate/docker-crate
+#
+
+FROM almalinux:9
+
+# Install prerequisites and package updates and clean up repository indexes again
+RUN yum install -y yum-utils \
+    && yum makecache \
+    && yum install -y python3 python3-pip \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
+# Install CrateDB
+RUN groupadd crate \
+    && useradd -u 1000 -g crate -d /crate crate \
+    && export PLATFORM="$( \
+        case $(uname --m) in \
+            x86_64)  echo x64_linux ;; \
+            aarch64) echo aarch64_linux ;; \
+        esac)" \
+    && export CRATE_URL={{ CRATE_RELEASE_URL }}/${PLATFORM}/{{ CRATE_TAR_GZ }} \
+    && curl -fSL -O ${CRATE_URL} \
+    && curl -fSL -O ${CRATE_URL}.asc \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
+    && gpg --batch --verify {{ CRATE_TAR_GZ }}.asc {{ CRATE_TAR_GZ }} \
+    && rm -rf "$GNUPGHOME" {{ CRATE_TAR_GZ }}.asc \
+    && tar -xf {{ CRATE_TAR_GZ }} -C /crate --strip-components=1 \
+    && rm {{ CRATE_TAR_GZ }}
+
+# Install crash
+RUN curl -fSL -O {{ CRASH_URL }} \
+    && curl -fSL -O {{ CRASH_URL }}.asc \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 90C23FC6585BC0717F8FBFC37FAAE51A06F6EAEB \
+    && gpg --batch --verify crash_standalone_{{ CRASH_VERSION }}.asc crash_standalone_{{ CRASH_VERSION }} \
+    && rm -rf "$GNUPGHOME" crash_standalone_{{ CRASH_VERSION }}.asc \
+    && mv crash_standalone_{{ CRASH_VERSION }} /usr/local/bin/crash \
+    && chmod +x /usr/local/bin/crash
+
+ENV PATH /crate/bin:$PATH
+# Default heap size for Docker, can be overwritten by args
+ENV CRATE_HEAP_SIZE 512M
+
+RUN mkdir -p /data/data /data/log
+
+VOLUME /data
+
+WORKDIR /data
+
+# http: 4200 tcp
+# transport: 4300 tcp
+# postgres protocol ports: 5432 tcp
+EXPOSE 4200 4300 5432
+
+# These COPY commands have been moved before the last one due to the following issues:
+# https://github.com/moby/moby/issues/37965#issuecomment-448926448
+# https://github.com/moby/moby/issues/38866
+COPY --chown=1000:0 config/crate.yml /crate/config/crate.yml
+COPY --chown=1000:0 config/log4j2.properties /crate/config/log4j2.properties
+
+LABEL maintainer="Crate.io <office@crate.io>" \
+    org.opencontainers.image.created="{{ BUILD_TIMESTAMP }}" \
+    org.opencontainers.image.title="crate" \
+    org.opencontainers.image.description="CrateDB is a distributed SQL database that handles massive amounts of machine data in real-time." \
+    org.opencontainers.image.url="https://crate.io/products/cratedb/" \
+    org.opencontainers.image.source="https://github.com/crate/docker-crate" \
+    org.opencontainers.image.vendor="Crate.io" \
+    org.opencontainers.image.version="{{ CRATE_VERSION }}"
+
+COPY docker-entrypoint.sh /
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["crate"]

--- a/Dockerfile_nightly.j2
+++ b/Dockerfile_nightly.j2
@@ -10,7 +10,7 @@ FROM almalinux:9
 # Install prerequisites and package updates and clean up repository indexes again
 RUN yum install -y yum-utils \
     && yum makecache \
-    && yum install -y python3 python3-pip openssl \
+    && yum install -y python3 python3-pip \
     && yum clean all \
     && rm -rf /var/cache/yum
 

--- a/Dockerfile_nightly.j2
+++ b/Dockerfile_nightly.j2
@@ -5,13 +5,11 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM almalinux:9
+FROM almalinux:9-minimal
 
-# Install prerequisites and package updates and clean up repository indexes again
-RUN yum install -y yum-utils \
-    && yum makecache \
-    && yum install -y python3 python3-pip \
-    && yum clean all \
+# Install prerequisites and clean up repository indexes again
+RUN microdnf install --nodocs --assumeyes gzip python3 shadow-utils tar \
+    && microdnf clean all \
     && rm -rf /var/cache/yum
 
 # Install CrateDB


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This PR includes the following changes:
* Created `Dockerfile-5.2.j2` before changing the base image, so we stick to the proven build process for stable releases. As far as I can see, [find_template_for_version](https://github.com/crate/docker-crate/blob/9b48bd55cc5929e9b59702316096599f21c742a4/update.py#L104) will pick that file automatically, so no further Jenkins-related changes should be needed?
* Changed the base image to `almalinux:9-minimal` in `Dockerfile(.j2)` (for CrateDB >= 5.3) as well as `Dockerfile_nightly.j2`
* Removal of `openssl` package upgrade, which was a leftover from the old CentOS-based image.
   With the minimal image, `openssl-libs` is installed by default:
   ```
   sh-5.1# microdnf repoquery --installed | grep openssl
   openssl-libs-1:3.0.1-43.el9_0.x86_64
   ```
   That package contains root certificates as well as the `libssl`/`libcrypto` shared libary files:
   ```
   sh-5.1# rpm -ql openssl-libs
    /etc/pki/tls
    /etc/pki/tls/certs <- directory with root certificates
    /etc/pki/tls/ct_log_list.cnf
    /etc/pki/tls/misc
    /etc/pki/tls/openssl.cnf
    /etc/pki/tls/private
    /usr/lib64/engines-3
    /usr/lib64/engines-3/afalg.so
    /usr/lib64/engines-3/capi.so
    /usr/lib64/engines-3/loader_attic.so
    /usr/lib64/engines-3/padlock.so
    /usr/lib64/libcrypto.so.3
    /usr/lib64/libcrypto.so.3.0.1
    /usr/lib64/libssl.so.3
    /usr/lib64/libssl.so.3.0.1
    /usr/lib64/ossl-modules
    /usr/lib64/ossl-modules/fips.so
    /usr/lib64/ossl-modules/legacy.so
   ```
   The `openssl` package itself is *not* installed by default, but only consists of the three binaries `make-dummy-cert`, `openssl`, and `renew-dummy-cert`.

## Comparison

On `amd64`, the uncompressed image size is:
* Before changes: 672 MB
* After changes: 544 MB

Which results in savings of 128 MB/19% 🚀.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
