### PR TITLE
Switch back to almalinux:9 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM almalinux:9-minimal
+FROM almalinux:9
 
 # Install prerequisites and clean up repository indexes again
-RUN microdnf install --nodocs --assumeyes gzip python3 shadow-utils tar \
-    && microdnf clean all \
+RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar \
+    && dnf clean all \
     && rm -rf /var/cache/yum
 
 # Install CrateDB

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -5,11 +5,11 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM almalinux:9-minimal
+FROM almalinux:9
 
 # Install prerequisites and clean up repository indexes again
-RUN microdnf install --nodocs --assumeyes gzip python3 shadow-utils tar \
-    && microdnf clean all \
+RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar \
+    && dnf clean all \
     && rm -rf /var/cache/yum
 
 # Install CrateDB

--- a/Dockerfile_nightly.j2
+++ b/Dockerfile_nightly.j2
@@ -5,11 +5,11 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM almalinux:9-minimal
+FROM almalinux:9
 
 # Install prerequisites and clean up repository indexes again
-RUN microdnf install --nodocs --assumeyes gzip python3 shadow-utils tar \
-    && microdnf clean all \
+RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar \
+    && dnf clean all \
     && rm -rf /var/cache/yum
 
 # Install CrateDB


### PR DESCRIPTION
We discovered regressions when running the AlmaLinux minimal image on Kubernetes. As a safety measure to not cause any similar problems to users, we are going back to the AlmaLinux standard image, effectively reverting GH-221.

When looking at the size savings, we also found that the *compressed* image size delta compared between standard and minimal is only 27 MB.

/cc @SStorm, @WalBeh, @proddata, @seut 