### PR TITLE
Bump base image to almalinux 10 minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM almalinux:9
+FROM almalinux:10-kitten-minimal
 
 # Install prerequisites and clean up repository indexes again
-RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar \
-    && dnf clean all \
+RUN microdnf install --nodocs --assumeyes gzip python3 shadow-utils tar gnupg \
+    && microdnf clean all \
     && rm -rf /var/cache/yum
 
 # Install CrateDB

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -5,11 +5,11 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM almalinux:9
+FROM almalinux:10-kitten-minimal
 
 # Install prerequisites and clean up repository indexes again
-RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar \
-    && dnf clean all \
+RUN microdnf install --nodocs --assumeyes gzip python3 shadow-utils tar gnupg \
+    && microdnf clean all \
     && rm -rf /var/cache/yum
 
 # Install CrateDB


### PR DESCRIPTION
CrateDB since 5.9.8 requires a glibc >= 2.39 because of OpenDAL
The one provided in almalinux:9 is too old (2.34)
