### PR TITLE
Update base image to AlmaLinux 10 non-minimal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM almalinux:10-kitten-minimal
+FROM almalinux:10-kitten
 
 # Install prerequisites and clean up repository indexes again
-RUN microdnf install --nodocs --assumeyes gzip python3 shadow-utils tar gnupg \
-    && microdnf clean all \
+RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar gnupg \
+    && dnf clean all \
     && rm -rf /var/cache/yum
 
 # Install CrateDB

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -5,11 +5,11 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM almalinux:10-kitten-minimal
+FROM almalinux:10-kitten
 
 # Install prerequisites and clean up repository indexes again
-RUN microdnf install --nodocs --assumeyes gzip python3 shadow-utils tar gnupg \
-    && microdnf clean all \
+RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar gnupg \
+    && dnf clean all \
     && rm -rf /var/cache/yum
 
 # Install CrateDB

--- a/Dockerfile_nightly.j2
+++ b/Dockerfile_nightly.j2
@@ -5,11 +5,11 @@
 # https://github.com/crate/docker-crate
 #
 
-FROM almalinux:10-kitten-minimal
+FROM almalinux:10-kitten
 
 # Install prerequisites and clean up repository indexes again
-RUN microdnf install --nodocs --assumeyes gzip python3 shadow-utils tar gnupg \
-    && microdnf clean all \
+RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar gnupg \
+    && dnf clean all \
     && rm -rf /var/cache/yum
 
 # Install CrateDB


### PR DESCRIPTION
## About

Better safe than sorry, use the non-minimal AlmaLinux image until we validated the minimal variant on all environments thoroughly.

@goat-ssh reported:

```
gcp: /crate/bin/crate: line 199: hostname: command not found 
....
ERROR: setting [node.attr.zone] must not be empty
```

NB: Please merge at your disposal.