### PR TITLE
OCI: Install `util-linux` to provide missing `rev` program

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 FROM almalinux:10-kitten
 
 # Install prerequisites and clean up repository indexes again
-RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar gnupg \
+RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar util-linux gnupg \
     && dnf clean all \
     && rm -rf /var/cache/yum
 

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -8,7 +8,7 @@
 FROM almalinux:10-kitten
 
 # Install prerequisites and clean up repository indexes again
-RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar gnupg \
+RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar util-linux gnupg \
     && dnf clean all \
     && rm -rf /var/cache/yum
 

--- a/Dockerfile_nightly.j2
+++ b/Dockerfile_nightly.j2
@@ -8,7 +8,7 @@
 FROM almalinux:10-kitten
 
 # Install prerequisites and clean up repository indexes again
-RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar gnupg \
+RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar util-linux gnupg \
     && dnf clean all \
     && rm -rf /var/cache/yum
 


### PR DESCRIPTION
The CrateDB Operator uses that command.
