### PR TITLE
CI: Run jobs on schedule each night to protect against regressions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,17 @@
 ---
 name: CrateDB Docker images test
-on: [push]
+on:
+  pull_request: ~
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   multi-arch-build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   test:


### PR DESCRIPTION
## About
This creates a stronger signal to be picked up by downstream monitoring components driven by [cratedb-github-summary](https://github.com/crate/cratedb-github-summary) and possibly others.

## References
- GH-255