### PR TITLE
Fix Jenkinsfile to run ./update.py with installed deps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,10 +4,10 @@ pipeline {
     stage("Parallel") {
       parallel {
         stage("Integration tests x86_64") {
-          agent { label "x64" }
+          agent { label "medium && x64" }
           steps {
             sh '''
-              uv venv --python 3.14
+              uv venv --python 3.14 --clear
               uv pip install -r requirements.txt
               VERSION=$(curl -s https://cratedb.com/versions.json | grep crate_testing | tr -d '" ' | cut -d ":" -f2)
               ./update.py --cratedb-version ${VERSION} > Dockerfile
@@ -16,10 +16,10 @@ pipeline {
           }
         }
         stage("Integration tests aarch64") {
-          agent { label "aarch64" }
+          agent { label "medium && aarch64" }
           steps {
             sh '''
-              uv venv --python 3.14
+              uv venv --python 3.14 --clear
               uv pip install -r requirements.txt
               VERSION=$(curl -s https://cratedb.com/versions.json | grep crate_testing | tr -d '" ' | cut -d ":" -f2)
               ./update.py --cratedb-version ${VERSION} > Dockerfile
@@ -28,15 +28,15 @@ pipeline {
           }
         }
         stage("Docker build & test x86_64") {
-          agent { label "x64" }
+          agent { label "medium && x64" }
           steps {
             sh 'git clean -xdff'
             checkout scm
             sh '''
-              uv venv
+              uv venv --python 3.14 --clear
               uv pip install -r requirements.txt
               VERSION=$(curl -s https://cratedb.com/versions.json | grep crate_testing | tr -d '" ' | cut -d ":" -f2)
-              ./update.py --cratedb-version ${VERSION} > Dockerfile
+              uv run ./update.py --cratedb-version ${VERSION} > Dockerfile
 
               docker build \
                 --pull \
@@ -54,15 +54,15 @@ pipeline {
         }
 
         stage("Docker build & test aarch64") {
-          agent { label "aarch64" }
+          agent { label "medium && aarch64" }
           steps {
             sh 'git clean -xdff'
             checkout scm
             sh '''
-              uv venv
+              uv venv --python 3.14 --clear
               uv pip install -r requirements.txt
               VERSION=$(curl -s https://cratedb.com/versions.json | grep crate_testing | tr -d '" ' | cut -d ":" -f2)
-              ./update.py --cratedb-version ${VERSION} > Dockerfile
+              uv run ./update.py --cratedb-version ${VERSION} > Dockerfile
 
               docker build \
                 --pull \


### PR DESCRIPTION
    ./update.py --cratedb-version 6.2.1
    Traceback (most recent call last):
      File "/var/lib/jenkins/workspace/CrateDB/Release/containers/crate_docker_tests/./update.py", line 8, in <module>
        from jinja2 import Environment, FileSystemLoader
    ModuleNotFoundError: No module named 'jinja2'
