### PR TITLE
Install crash using pip, stop using the standalone executable builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 FROM almalinux:10-kitten
 
 # Install prerequisites and clean up repository indexes again
-RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar util-linux gnupg \
+RUN dnf install --nodocs --assumeyes gzip python3 python3-pip shadow-utils tar util-linux gnupg \
     && dnf clean all \
     && rm -rf /var/cache/yum
 
@@ -30,9 +30,7 @@ RUN groupadd crate \
     && rm crate-6.2.1.tar.gz
 
 # Install crash
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-RUN uv tool install 'crash==0.31.5'
-ENV PATH=/root/.local/bin:$PATH
+RUN python3 -m pip install 'crash==0.31.5'
 
 ENV PATH /crate/bin:$PATH
 # Default heap size for Docker, can be overwritten by args

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -8,7 +8,7 @@
 FROM almalinux:10-kitten
 
 # Install prerequisites and clean up repository indexes again
-RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar util-linux gnupg \
+RUN dnf install --nodocs --assumeyes gzip python3 python3-pip shadow-utils tar util-linux gnupg \
     && dnf clean all \
     && rm -rf /var/cache/yum
 
@@ -31,9 +31,7 @@ RUN groupadd crate \
     && rm {{ CRATE_TAR_GZ }}
 
 # Install crash
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-RUN uv tool install 'crash=={{ CRASH_VERSION }}'
-ENV PATH=/root/.local/bin:$PATH
+RUN python3 -m pip install 'crash=={{ CRASH_VERSION }}'
 
 ENV PATH /crate/bin:$PATH
 # Default heap size for Docker, can be overwritten by args

--- a/Dockerfile_5.0.j2
+++ b/Dockerfile_5.0.j2
@@ -35,9 +35,7 @@ RUN groupadd crate \
     && rm {{ CRATE_TAR_GZ }}
 
 # Install crash
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-RUN uv tool install 'crash=={{ CRASH_VERSION }}'
-ENV PATH=/root/.local/bin:$PATH
+RUN python3 -m pip install 'crash=={{ CRASH_VERSION }}'
 
 ENV PATH /crate/bin:$PATH
 # Default heap size for Docker, can be overwritten by args

--- a/Dockerfile_5.1.j2
+++ b/Dockerfile_5.1.j2
@@ -35,9 +35,7 @@ RUN groupadd crate \
     && rm {{ CRATE_TAR_GZ }}
 
 # Install crash
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-RUN uv tool install 'crash=={{ CRASH_VERSION }}'
-ENV PATH=/root/.local/bin:$PATH
+RUN python3 -m pip install 'crash=={{ CRASH_VERSION }}'
 
 ENV PATH /crate/bin:$PATH
 # Default heap size for Docker, can be overwritten by args

--- a/Dockerfile_5.2.j2
+++ b/Dockerfile_5.2.j2
@@ -33,9 +33,7 @@ RUN groupadd crate \
     && rm {{ CRATE_TAR_GZ }}
 
 # Install crash
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-RUN uv tool install 'crash=={{ CRASH_VERSION }}'
-ENV PATH=/root/.local/bin:$PATH
+RUN python3 -m pip install 'crash=={{ CRASH_VERSION }}'
 
 ENV PATH /crate/bin:$PATH
 # Default heap size for Docker, can be overwritten by args

--- a/Dockerfile_nightly.j2
+++ b/Dockerfile_nightly.j2
@@ -8,7 +8,7 @@
 FROM almalinux:10-kitten
 
 # Install prerequisites and clean up repository indexes again
-RUN dnf install --nodocs --assumeyes gzip python3 shadow-utils tar util-linux gnupg \
+RUN dnf install --nodocs --assumeyes gzip python3 python3-pip shadow-utils tar util-linux gnupg \
     && dnf clean all \
     && rm -rf /var/cache/yum
 
@@ -31,9 +31,7 @@ RUN groupadd crate \
     && rm {{ CRATE_TAR_GZ }}
 
 # Install crash
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-RUN uv tool install 'crash=={{ CRASH_VERSION }}'
-ENV PATH=/root/.local/bin:$PATH
+RUN python3 -m pip install 'crash=={{ CRASH_VERSION }}'
 
 ENV PATH /crate/bin:$PATH
 # Default heap size for Docker, can be overwritten by args


### PR DESCRIPTION
## About

The reason is that crate-python started using the orjson package, which is distributed as binary wheels. In this spirit, the whole custom build chain of crash would need to run a matrix along the version and architecture axis, matching them properly to each other.

Contrary to that, using a vanilla installation method saves infrastructure cycles by just installing the package from PyPI.

## References
- https://github.com/crate/crash/issues/488