### PR TITLE
Run itests in same stage as build/official-image test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,30 +3,6 @@ pipeline {
   stages {
     stage("Parallel") {
       parallel {
-        stage("Integration tests x86_64") {
-          agent { label "medium && x64" }
-          steps {
-            sh '''
-              uv venv --python 3.14 --clear
-              uv pip install -r requirements.txt
-              VERSION=$(curl -s https://cratedb.com/versions.json | grep crate_testing | tr -d '" ' | cut -d ":" -f2)
-              uv run update.py --cratedb-version ${VERSION} > Dockerfile
-            '''.stripIndent()
-            sh 'uv run -m unittest -v'
-          }
-        }
-        stage("Integration tests aarch64") {
-          agent { label "medium && aarch64" }
-          steps {
-            sh '''
-              uv venv --python 3.14 --clear
-              uv pip install -r requirements.txt
-              VERSION=$(curl -s https://cratedb.com/versions.json | grep crate_testing | tr -d '" ' | cut -d ":" -f2)
-              uv run update.py --cratedb-version ${VERSION} > Dockerfile
-            '''.stripIndent()
-            sh 'uv run -m unittest -v'
-          }
-        }
         stage("Docker build & test x86_64") {
           agent { label "medium && x64" }
           steps {
@@ -50,6 +26,7 @@ pipeline {
               git clone --filter=blob:none https://github.com/docker-library/official-images.git ./official-images
               ./official-images/test/run.sh crate/crate:ci_test
             '''.stripIndent()
+            sh 'uv run -m unittest -v'
           }
         }
 
@@ -76,6 +53,7 @@ pipeline {
               git clone --filter=blob:none https://github.com/docker-library/official-images.git ./official-images
               ./official-images/test/run.sh crate/crate:ci_test
             '''.stripIndent()
+            sh 'uv run -m unittest -v'
           }
         }
       }


### PR DESCRIPTION
To prevent concurrent runs from conflicting:

    docker.errors.APIError: 409 Client Error for http+docker://localhost/v1.50/containers/create?name=crate: Conflict ("Conflict. The container name "/crate" is already in use by container "3f419610d31cb7a7cfbab84fa3e8679606686cfded4397216b0ea6bb8ac4f898". You have to remove (or rename) that container to be able to reuse that name.")
